### PR TITLE
fix: rename ecr_arn and inject it into etl_module

### DIFF
--- a/aws/etl_lambdas/inputs.tf
+++ b/aws/etl_lambdas/inputs.tf
@@ -10,7 +10,7 @@ variable "csv_etl_tag" {
   type = string
 }
 
-variable "create_csv_ecr_arn" {
+variable "create_csv_repository_arn" {
   type = string
 }
 

--- a/aws/etl_lambdas/policies.tf
+++ b/aws/etl_lambdas/policies.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "etl_policies" {
       "ecr:BatchGetImage"
     ]
     resources = [
-      var.create_csv_ecr_arn
+      var.create_csv_repository_arn
     ]
   }
 

--- a/env/staging/etl_lambda/terragrunt.hcl
+++ b/env/staging/etl_lambda/terragrunt.hcl
@@ -41,6 +41,7 @@ inputs = {
 
   csv_etl_repository_url = dependency.ecr.outputs.create_csv_repository_url
   csv_etl_tag            = "latest"
+  create_csv_repository_arn     = depenency.ecr.outputs.create_csv_repository_arn
 
   csv_etl_sg_id             = dependency.network.outputs.csv_etl_sg_id
   metrics_private_subnet_id = dependency.network.outputs.private_subnet_id

--- a/env/staging/etl_lambda/terragrunt.hcl
+++ b/env/staging/etl_lambda/terragrunt.hcl
@@ -39,9 +39,9 @@ dependency "s3" {
 
 inputs = {
 
-  csv_etl_repository_url = dependency.ecr.outputs.create_csv_repository_url
-  csv_etl_tag            = "latest"
-  create_csv_repository_arn     = depenency.ecr.outputs.create_csv_repository_arn
+  csv_etl_repository_url    = dependency.ecr.outputs.create_csv_repository_url
+  csv_etl_tag               = "latest"
+  create_csv_repository_arn = dependency.ecr.outputs.create_csv_repository_arn
 
   csv_etl_sg_id             = dependency.network.outputs.csv_etl_sg_id
   metrics_private_subnet_id = dependency.network.outputs.private_subnet_id


### PR DESCRIPTION
# Summary | Résumé

- Rename the input variable in etl_lambda from `create_csv_ecr_arn` to `create_csv_repository_arn` to better represent what it is.
- inject the variable into the etl_lambda module
