### PR TITLE
fix: allow role to read dynamodb

### DIFF
--- a/aws/etl_lambdas/policies.tf
+++ b/aws/etl_lambdas/policies.tf
@@ -31,9 +31,11 @@ data "aws_iam_policy_document" "etl_policies" {
 
     effect = "Allow"
     actions = [
-      "dynamodb:GetRecords",
-      "dynamodb:GetShardIterator",
-      "dynamodb:ListShards"
+      "dynamodb:GetItem",
+      "dynamodb:BatchGetItem",
+      "dynamodb:Scan",
+      "dynamodb:Query",
+      "dynamodb:ConditionCheckItem"
     ]
     resources = [
       data.aws_dynamodb_table.aggregate_metrics.arn


### PR DESCRIPTION
Apply the proper permission set to read a dynamodb table

