### PR TITLE
feat: use OPA to check for TF plan changes

### DIFF
--- a/.github/workflows/policy/no-changes.rego
+++ b/.github/workflows/policy/no-changes.rego
@@ -6,6 +6,11 @@ import input as tfplan
 # Policy: check there are no resource or output changes
 #######################################################
 
+no_changes {
+	no_change_resource
+	no_change_output
+}
+
 no_change_resource {
 	count_resouce_changes("create") == 0
 	count_resouce_changes("update") == 0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -100,6 +100,7 @@ jobs:
           set -o pipefail
           cd env/staging/${{matrix.module_name}}
           terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$GITHUB_WORKSPACE/tfplan.binary" |& tee tempfile
+          terragrunt show -json "$GITHUB_WORKSPACE/tfplan.binary" > tfplan.json
           plan_output=$(cat tempfile)
           plan_output="${plan_output//'%'/'%25'}"
           plan_output="${plan_output//$'\n'/'%0A'}"
@@ -110,7 +111,6 @@ jobs:
       - name: Check plan changes
         id: check-changes
         run: |
-          terragrunt show -json "$GITHUB_WORKSPACE/tfplan.binary" > tfplan.json
           no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input tfplan.json "data.terraform.analysis.no_changes")
           echo "::set-output name=no-changes::$no_changes"
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,14 +5,15 @@ on:
     paths:
       - "aws/**"
       - "env/staging/**"
-      - ".github/workflows/*"
+      - ".github/workflows/**"
 
 env:
+  OPA_VERSION: v0.28.0
   TERRAFORM_VERSION: 0.14.2
   TERRAGRUNT_VERSION: v0.29.2
 
 jobs:
-  terragrunt-hcl-check:
+  lint:
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
@@ -28,17 +29,23 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Setup Terragrunt
+      - name: Setup Terragrunt and OPA
         run: |
           mkdir bin
           wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/terragrunt
+          wget -O bin/opa https://github.com/open-policy-agent/opa/releases/download/$OPA_VERSION/opa_linux_amd64
+          chmod +x bin/*
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Lint HCL files
         run: |
           cd env
           terragrunt hclfmt --terragrunt-check
+
+      - name: Lint Rego files
+        run: |
+          cd .github/workflows/policy
+          opa check *.rego
 
   terraform-plan-staging:
     runs-on: ubuntu-latest
@@ -65,11 +72,12 @@ jobs:
           terraform_version: ${{ env.TERRAFORM_VERSION }}
           terraform_wrapper: false
 
-      - name: Setup Terragrunt
+      - name: Setup Terragrunt and OPA
         run: |
           mkdir bin
           wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/terragrunt
+          wget -O bin/opa https://github.com/open-policy-agent/opa/releases/download/$OPA_VERSION/opa_linux_amd64
+          chmod +x bin/*
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
 
       - name: Validate Module 
@@ -89,8 +97,9 @@ jobs:
       - name: Plan module
         id: plan
         run: |
+          set -o pipefail
           cd env/staging/${{matrix.module_name}}
-          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color |& tee tempfile
+          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$GITHUB_WORKSPACE/tfplan.binary" |& tee tempfile
           plan_output=$(cat tempfile)
           plan_output="${plan_output//'%'/'%25'}"
           plan_output="${plan_output//$'\n'/'%0A'}"
@@ -98,8 +107,16 @@ jobs:
           echo "::set-output name=stdout::$plan_output"
         continue-on-error: true
 
+      - name: Check plan changes
+        id: check-changes
+        run: |
+          terragrunt show -json "$GITHUB_WORKSPACE/tfplan.binary" > tfplan.json
+          no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input tfplan.json "data.terraform.analysis.no_changes")
+          echo "::set-output name=no-changes::$no_changes"
+
+      # Create plan comment for PRs if there are changes or the format/plan steps failed
       - uses: actions/github-script@0.9.0
-        if: github.event_name == 'pull_request'
+        if: ${{ github.event_name == 'pull_request' && (steps.check-changes.no-changes != 'true' || steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure') }}
         env:
           PLAN: "${{ steps.plan.outputs.stdout }}"
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,6 +53,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
+      TFPLAN_BINARY: "$GITHUB_WORKSPACE/tfplan.binary"
+      TFPLAN_JSON: "$GITHUB_WORKSPACE/tfplan.json"
     strategy:
       fail-fast: false
       matrix:
@@ -99,8 +101,8 @@ jobs:
         run: |
           set -o pipefail
           cd env/staging/${{matrix.module_name}}
-          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$GITHUB_WORKSPACE/tfplan.binary" |& tee tempfile
-          terragrunt show -json "$GITHUB_WORKSPACE/tfplan.binary" > tfplan.json
+          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$TFPLAN_BINARY" |& tee tempfile
+          terragrunt show -json "$TFPLAN_BINARY" > "$TFPLAN_JSON"
           plan_output=$(cat tempfile)
           plan_output="${plan_output//'%'/'%25'}"
           plan_output="${plan_output//$'\n'/'%0A'}"
@@ -111,7 +113,7 @@ jobs:
       - name: Check plan changes
         id: check-changes
         run: |
-          no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input tfplan.json "data.terraform.analysis.no_changes")
+          no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input "$TFPLAN_JSON" "data.terraform.analysis.no_changes")
           echo "::set-output name=no-changes::$no_changes"
 
       # Create plan comment for PRs if there are changes or the format/plan steps failed

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -53,8 +53,6 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
-      TFPLAN_BINARY: "$GITHUB_WORKSPACE/tfplan.binary"
-      TFPLAN_JSON: "$GITHUB_WORKSPACE/tfplan.json"
     strategy:
       fail-fast: false
       matrix:
@@ -101,8 +99,8 @@ jobs:
         run: |
           set -o pipefail
           cd env/staging/${{matrix.module_name}}
-          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$TFPLAN_BINARY" |& tee tempfile
-          terragrunt show -json "$TFPLAN_BINARY" > "$TFPLAN_JSON"
+          terragrunt plan --terragrunt-non-interactive --terragrunt-log-level warn -no-color -out="$GITHUB_WORKSPACE/tfplan.binary" |& tee tempfile
+          terragrunt show -json "$GITHUB_WORKSPACE/tfplan.binary" > "$GITHUB_WORKSPACE/tfplan.json"
           plan_output=$(cat tempfile)
           plan_output="${plan_output//'%'/'%25'}"
           plan_output="${plan_output//$'\n'/'%0A'}"
@@ -113,7 +111,7 @@ jobs:
       - name: Check plan changes
         id: check-changes
         run: |
-          no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input "$TFPLAN_JSON" "data.terraform.analysis.no_changes")
+          no_changes=$(opa eval --format pretty --data .github/workflows/policy/no-changes.rego --input "$GITHUB_WORKSPACE/tfplan.json" "data.terraform.analysis.no_changes")
           echo "::set-output name=no-changes::$no_changes"
 
       # Create plan comment for PRs if there are changes or the format/plan steps failed

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -116,7 +116,7 @@ jobs:
 
       # Create plan comment for PRs if there are changes or the format/plan steps failed
       - uses: actions/github-script@0.9.0
-        if: ${{ github.event_name == 'pull_request' && (steps.check-changes.no-changes != 'true' || steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure') }}
+        if: ${{ github.event_name == 'pull_request' && (steps.check-changes.outputs.no-changes != 'true' || steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure') }}
         env:
           PLAN: "${{ steps.plan.outputs.stdout }}"
         with:


### PR DESCRIPTION
This checks the TF plan output to determine if there are any resource or output changes.  This is then used to control if the plan comment should be added to the PR.

Also includes a fix to prevent the terragrunt exit code from being hidden by the pipe to tee.

Closes #6 
Closes #15 
