### PR TITLE
fix: explicitly set default Network ACL subnets

### DIFF
--- a/aws/network/nacl.tf
+++ b/aws/network/nacl.tf
@@ -1,6 +1,8 @@
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = aws_vpc.main.default_network_acl_id
 
+  subnet_ids = [aws_subnet.private.id, aws_subnet.public.id]
+
   tags = {
     Name = "${var.name}_default_nacl"
   }

--- a/aws/network/nacl.tf
+++ b/aws/network/nacl.tf
@@ -1,14 +1,20 @@
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = aws_vpc.main.default_network_acl_id
 
-  subnet_ids = [aws_subnet.private.id, aws_subnet.public.id]
-
   tags = {
     Name = "${var.name}_default_nacl"
   }
+}
+
+resource "aws_network_acl" "main" {
+  vpc_id     = aws_vpc.main.id
+  subnet_ids = [aws_subnet.private.id, aws_subnet.public.id]
+
+  tags = {
+    Name = "${var.name}_main_nacl"
+  }
 
   ingress {
-
     rule_no    = 100
     protocol   = "tcp"
     action     = "allow"
@@ -19,7 +25,6 @@ resource "aws_default_network_acl" "default" {
   }
 
   ingress {
-
     rule_no    = 101
     protocol   = "tcp"
     action     = "allow"
@@ -30,7 +35,6 @@ resource "aws_default_network_acl" "default" {
   }
 
   egress {
-
     rule_no    = 102
     protocol   = -1
     action     = "allow"


### PR DESCRIPTION
This removes the repeated subnet update shown in TF plans.  This is explained in the [aws_default_network_acl docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl):

> Because Subnets are by default associated with the Default Network ACL, any non-explicit association will show up as a plan to remove the Subnet.

Fixes #16 


