### PR TITLE
feat: add network infra for efs

### DIFF
--- a/aws/network/efs_sg.tf
+++ b/aws/network/efs_sg.tf
@@ -1,0 +1,22 @@
+resource "aws_security_group" "efs" { 
+  description = "Used by EFS"
+  vpc_id = aws_vpc.main.id
+
+  tags = { 
+    Name = "${var.name}_efs_sg"
+  }
+
+  lifecycle { 
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "nfs_ingress" {
+  description              = "Allow communication to NFS"
+  type                     = "ingress"
+  from_port                = 2049
+  to_port                  = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.efs.id
+  source_security_group_id = aws_security_group.lambda.id
+}

--- a/aws/network/efs_sg.tf
+++ b/aws/network/efs_sg.tf
@@ -11,8 +11,8 @@ resource "aws_security_group" "efs" {
   }
 }
 
-resource "aws_security_group_rule" "nfs_ingress" {
-  description              = "Allow communication to NFS"
+resource "aws_security_group_rule" "efs_ingress" {
+  description              = "Allow communication to EFS from the lambda sg"
   type                     = "ingress"
   from_port                = 2049
   to_port                  = 2049

--- a/aws/network/efs_sg.tf
+++ b/aws/network/efs_sg.tf
@@ -1,12 +1,12 @@
-resource "aws_security_group" "efs" { 
+resource "aws_security_group" "efs" {
   description = "Used by EFS"
-  vpc_id = aws_vpc.main.id
+  vpc_id      = aws_vpc.main.id
 
-  tags = { 
+  tags = {
     Name = "${var.name}_efs_sg"
   }
 
-  lifecycle { 
+  lifecycle {
     create_before_destroy = true
   }
 }

--- a/aws/network/lambda_sg.tf
+++ b/aws/network/lambda_sg.tf
@@ -22,12 +22,12 @@ resource "aws_security_group_rule" "inet_egress" {
   security_group_id = aws_security_group.lambda.id
 }
 
-resource "aws_security_group_rule" "efs_egress" { 
-  description = "Allow lambda to egress to efs"
-  type = "egress"
-  to_port = 2049
-  from_port = 2049
-  protocol = "tcp"
-  security_group_id = aws_security_group.lambda.id
+resource "aws_security_group_rule" "efs_egress" {
+  description              = "Allow lambda to egress to efs"
+  type                     = "egress"
+  to_port                  = 2049
+  from_port                = 2049
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.lambda.id
   source_security_group_id = aws_security_group.efs.id
 }

--- a/aws/network/lambda_sg.tf
+++ b/aws/network/lambda_sg.tf
@@ -1,8 +1,4 @@
 
-resource "aws_default_security_group" "default" {
-  vpc_id = aws_vpc.main.id
-}
-
 resource "aws_security_group" "lambda" {
   description = "Used by lamba for access to the internet and the S3/DynamoDB private endpoints"
   vpc_id      = aws_vpc.main.id
@@ -24,4 +20,14 @@ resource "aws_security_group_rule" "inet_egress" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:AWS007  required to pull in lambda's data
   security_group_id = aws_security_group.lambda.id
+}
+
+resource "aws_security_group_rule" "efs_egress" { 
+  description = "Allow lambda to egress to efs"
+  type = "egress"
+  to_port = 2049
+  from_port = 2049
+  protocol = "tcp"
+  security_group_id = aws_security_group.lambda.id
+  source_security_group_id = aws_security_group.efs.id
 }

--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -2,6 +2,10 @@ output "csv_etl_sg_id" {
   value = aws_security_group.lambda.id
 }
 
+output "efs_sg_id" { 
+  value = aws_security_group.efs.id
+}
+
 output "private_subnet_id" {
   value = aws_subnet.private.id
 }

--- a/aws/network/outputs.tf
+++ b/aws/network/outputs.tf
@@ -2,7 +2,7 @@ output "csv_etl_sg_id" {
   value = aws_security_group.lambda.id
 }
 
-output "efs_sg_id" { 
+output "efs_sg_id" {
   value = aws_security_group.efs.id
 }
 

--- a/aws/network/vpc.tf
+++ b/aws/network/vpc.tf
@@ -59,3 +59,7 @@ resource "aws_internet_gateway" "gw" {
   }
 
 }
+
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}


### PR DESCRIPTION
This is the first step in a multi pr process. 

First we are creating a network security group for an EFS and allowing ingress over port 2049 (NFS) so that things can talk to the EFS. 

We are also adding an egress rule to the Lambda SG so that it can talk to the new EFS SG. 

Next we'll be attaching the EFS into the new SG but the sg has to be there first. 

