### PR TITLE
feat: attach the lambda insights exec role to lambdas

### DIFF
--- a/aws/etl_lambdas/policies.tf
+++ b/aws/etl_lambdas/policies.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy" "lambda_insights" {
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_insights" {
-  role = aws_iam_role.metrics_csv.name
+  role       = aws_iam_role.metrics_csv.name
   policy_arn = data.aws_iam_policy.lambda_insights.arn
 }
 

--- a/aws/etl_lambdas/policies.tf
+++ b/aws/etl_lambdas/policies.tf
@@ -8,6 +8,15 @@ resource "aws_iam_role_policy_attachment" "etl_policies" {
   policy_arn = aws_iam_policy.etl_policies.arn
 }
 
+data "aws_iam_policy" "lambda_insights" {
+  name = "CloudWatchLambdaInsightsExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_insights" {
+  role = aws_iam_role.metrics_csv.name
+  policy_arn = data.aws_iam_policy.lambda_insights.arn
+}
+
 data "aws_iam_policy_document" "service_principal" {
   statement {
     effect = "Allow"


### PR DESCRIPTION
Attaches the CloudWatchLambdaInsightsExecutionRolePolicy role to the role used by the lambdas so we can enable Lambda Insights on these two lambdas. 

See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-Getting-Started-docker.html
