### PR TITLE
feat: Add required outputs

### DIFF
--- a/aws/dynamodb/outputs.tf
+++ b/aws/dynamodb/outputs.tf
@@ -2,7 +2,7 @@ output "raw_metrics_arn" {
   value = aws_dynamodb_table.raw_metrics.arn
 }
 
-output "raw_metrics_stream_arn" { 
+output "raw_metrics_stream_arn" {
   value = aws_dynamodb_table.raw_metrics.stream_arn
 }
 

--- a/aws/dynamodb/outputs.tf
+++ b/aws/dynamodb/outputs.tf
@@ -1,0 +1,11 @@
+output "raw_metrics_arn" {
+  value = aws_dynamodb_table.raw_metrics.arn
+}
+
+output "raw_metrics_stream_arn" { 
+  value = aws_dynamodb_table.raw_metrics.stream_arn
+}
+
+output "aggregate_metrics_arn" {
+  value = aws_dynamodb_table.aggregate_metrics.arn
+}

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -2,10 +2,10 @@ output "metrics_key_arn" {
   value = aws_kms_key.metrics_key.arn
 }
 
-output "dead_letter_queue_arn" { 
+output "dead_letter_queue_arn" {
   value = aws_sqs_queue.aggregation_lambda_dead_letter.arn
 }
 
-output "dead_letter_queue_url" { 
+output "dead_letter_queue_url" {
   value = aws_sqs_queue.aggregation_lambda_dead_letter.id
 }

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -2,3 +2,10 @@ output "metrics_key_arn" {
   value = aws_kms_key.metrics_key.arn
 }
 
+output "dead_letter_queue_arn" { 
+  value = aws_sqs_queue.aggregation_lambda_dead_letter.arn
+}
+
+output "dead_letter_queue_url" { 
+  value = aws_sqs_queue.aggregation_lambda_dead_letter.id
+}


### PR DESCRIPTION
Add outputs needed to migrate over the backoff retry lambda

This should only add new outputs
