### PR TITLE
feat: backup branch to an S3 buckup daily

### DIFF
--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -1,0 +1,29 @@
+name: S3 backup
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+env:
+  BACKUP_BRANCH: main
+
+jobs:
+  s3-backup:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_S3_BACKUP_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_S3_BACKUP_SECRET_ACCESS_KEY }}
+        aws-region: ca-central-1
+
+    - name: Get ZIP bundle
+      run: |
+        mkdir -p ${{ github.repository }}
+        wget -O ${{ github.repository }}/`basename ${{ github.repository }}`-`date '+%Y-%m-%d'`.zip https://github.com/${{ github.repository }}/archive/${{ env.BACKUP_BRANCH }}.zip
+
+    - name: Upload to S3 bucket
+      run: |
+        aws s3 sync . s3://${{ secrets.AWS_S3_BACKUP_BUCKET }} --exclude='*' --include='${{ github.repository }}/*'


### PR DESCRIPTION
This provides an additional backup of the project's code if
GitHub and its backups are unavailable.

Related cds-snc/site-reliability-engineering#194