### PR TITLE
feat: add a gsi on the identifier

### DIFF
--- a/aws/backoff_retry_lambda/alarm.tf
+++ b/aws/backoff_retry_lambda/alarm.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "backoff_retry_average_duration" {
-  alarm_name          = "save-metrics-average-duration"
+  alarm_name          = "backoff-retry--average-duration"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "Duration"

--- a/aws/dynamodb/aggregate_metrics_table.tf
+++ b/aws/dynamodb/aggregate_metrics_table.tf
@@ -23,4 +23,10 @@ resource "aws_dynamodb_table" "aggregate_metrics" {
     enabled = true
   }
 
+  global_secondary_index {
+    name               = "IdentifierIndex"
+    hash_key           = "identifier"
+    projection_type    = "ALL"
+  }
+
 }

--- a/aws/dynamodb/aggregate_metrics_table.tf
+++ b/aws/dynamodb/aggregate_metrics_table.tf
@@ -19,14 +19,19 @@ resource "aws_dynamodb_table" "aggregate_metrics" {
     type = "S"
   }
 
+  attribute {
+    name = "identifier"
+    type = "S"
+  }
+
   point_in_time_recovery {
     enabled = true
   }
 
   global_secondary_index {
-    name               = "IdentifierIndex"
-    hash_key           = "identifier"
-    projection_type    = "ALL"
+    name            = "IdentifierIndex"
+    hash_key        = "identifier"
+    projection_type = "ALL"
   }
 
 }


### PR DESCRIPTION
To improve the speed of the ETL script we are creating a global
secondary index on the identifier field.

This will allow us to run queries on that field instead of scanning the
entire db and then filtering on the identifier that we currently do.

