### PR TITLE
feat: add Checkov Terraform static analysis

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,31 @@
+name: "Security scan"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "aws/**"
+      - "env/common/**"
+      - ".github/workflows/**"
+
+env:
+  CHECKOV_VERSION: 00cc657f4d415593e5c8897bc87f490497ccb5f9 # v12.641.0
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkov security scan
+        id: checkov
+        uses: bridgecrewio/checkov-action@${{ env.CHECKOV_VERSION }}
+        with:
+          directory: .
+          soft_fail: true
+          framework: terraform
+          output_format: cli
+          download_external_modules: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,9 +10,6 @@ on:
       - "env/common/**"
       - ".github/workflows/**"
 
-env:
-  CHECKOV_VERSION: 00cc657f4d415593e5c8897bc87f490497ccb5f9 # v12.641.0
-
 jobs:
   security-scan:
     runs-on: ubuntu-latest
@@ -22,7 +19,7 @@ jobs:
 
       - name: Checkov security scan
         id: checkov
-        uses: bridgecrewio/checkov-action@${{ env.CHECKOV_VERSION }}
+        uses: bridgecrewio/checkov-action@00cc657f4d415593e5c8897bc87f490497ccb5f9 # v12.641.0
         with:
           directory: .
           soft_fail: true


### PR DESCRIPTION
Scans the `*.tf` code for potential security problems.

Currently this does not fail the pipeline if security problems are found to give us time to address the failures.  Once that's taken care, this can be set to hard fail pipelines with security problems.

Related #2 