### PR TITLE
feat: migrate staging API gateway CloudWatch alarms

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,6 +52,9 @@ jobs:
           - module_name: dynamodb
             environment: production
 
+          - module_name: cloudwatch_alarms
+            environment: staging            
+
     steps:
 
       - name: Checkout

--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -1,0 +1,70 @@
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_500_errors_above_threshold" {
+  alarm_name          = "metrics-api-gateway-errors-above-threshold"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "5XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_500_error_threshold
+  alarm_description   = "This metric monitors 500 errors in the metrics API gateway"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = data.aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_min_invocations_threshold" {
+  alarm_name          = "metrics-api-gateway-below-minimum-invocations"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Count"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_min_invocations
+  alarm_description   = "This metric monitors minimum API gateway invocations for the metrics API gateway"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = data.aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_invocations_threshold" {
+  count               = var.feature_api_alarms ? 1 : 0
+  alarm_name          = "metrics-api-gateway-above-maximum-invocations"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Count"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_max_invocations
+  alarm_description   = "This metric monitors maximum API gateway invocations for the metrics API gateway"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = data.aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshold" {
+  alarm_name          = "metrics-api-gateway-above-maximum-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Latency"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  extended_statistic  = "p95"
+  threshold           = var.api_gateway_max_latency
+  alarm_description   = "This metric monitors maximum API gateway latency for the metrics API gateway"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = data.aws_api_gateway_rest_api.metrics.name
+  }
+}
+
+

--- a/aws/cloudwatch_alarms/data_lookups.tf
+++ b/aws/cloudwatch_alarms/data_lookups.tf
@@ -1,0 +1,11 @@
+data "aws_api_gateway_rest_api" "metrics" {
+  name = var.metrics_api_gateway_name
+}
+
+data "aws_sns_topic" "alert_warning" {
+  name = var.sns_topic_warning_name
+}
+
+data "aws_sns_topic" "alert_critical" {
+  name = var.sns_topic_critical_name
+}

--- a/aws/cloudwatch_alarms/inputs.tf
+++ b/aws/cloudwatch_alarms/inputs.tf
@@ -1,0 +1,40 @@
+variable "metrics_api_gateway_name" {
+  description = "Name of the metrics API gateway"
+  type        = string
+}
+
+variable "sns_topic_warning_name" {
+  description = "SNS topic name for warning alerts"
+  type        = string
+}
+
+variable "sns_topic_critical_name" {
+  description = "SNS topic name for critical alerts"
+  type        = string
+}
+
+variable "feature_api_alarms" {
+  description = "Should API gateway alarms be created"
+  type        = bool
+  default     = true
+}
+
+variable "api_gateway_500_error_threshold" {
+  description = "Maximum sum of 5xx errors in a 60 second period before an alarm triggers"
+  type        = string
+}
+
+variable "api_gateway_min_invocations" {
+  description = "Minimum sum of requests in a 60 second period before an alarm triggers"
+  type        = string
+}
+
+variable "api_gateway_max_invocations" {
+  description = "Maximum sum of requests in a 60 second period before an alarm triggers"
+  type        = string
+}
+
+variable "api_gateway_max_latency" {
+  description = "Maximum latency (milliseconds) in a 60 second period before an alarm triggers"
+  type        = string
+}

--- a/env/staging/cloudwatch_alarms/.terraform.lock.hcl
+++ b/env/staging/cloudwatch_alarms/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.43.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:9AUqenvmqU3Q1+iRYBRUcxyT8PCnRPy0/jFqKYucA/I=",
+    "zh:1496d971301216bfd27aada08f83315748972a50782c3c7a998212d733a8bd4f",
+    "zh:3f43fd130eaf6ff82d713add40d38a526e978975e9517defabb32fe056a32371",
+    "zh:52db549bf4d77235beb01c7bba72d577aa141a812cc1045a2808b40d2262fc3d",
+    "zh:5ebdcedc4057d65e2d5689d15534eb8b4d175d8138952a298fba1c3e881c01c5",
+    "zh:6264aacffd2caf82eabde2f3298cfed44377a2839dd88c67c860b83589c15129",
+    "zh:759a6993c6692fd19ae83add4fd11c6be4e74adb5e7a02baff278386d4a89990",
+    "zh:8a5975e90215a6c7af4eddf6fcdffb8e4aab4ff7885409728d78fff6c9e37235",
+    "zh:8dd00c37cf496487066129ed19a0f7eae090cef333251789d945bc35c1723ab6",
+    "zh:a0b615859497deeb95d09336a4a0c87e3687092188950b029434f742928fd299",
+    "zh:e7d588099ec1868fd419cce7dc54c717816d3cb2206cc9564b6ace2a82d14f79",
+    "zh:faf8443d3f87fc41d20a5867c5efecaa2c56d97b83c8f30c485c3b5dd4b7a226",
+  ]
+}

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -1,7 +1,7 @@
 inputs = {
-  metrics_api_gateway_name        = "save-metrics"
-  sns_topic_warning_name          = "alert-warning"
-  sns_topic_critical_name         = "alert-critical"
+  metrics_api_gateway_name = "save-metrics"
+  sns_topic_warning_name   = "alert-warning"
+  sns_topic_critical_name  = "alert-critical"
 
   feature_api_alarms              = true
   api_gateway_500_error_threshold = 95

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -1,0 +1,19 @@
+inputs = {
+  metrics_api_gateway_name        = "save-metrics"
+  sns_topic_warning_name          = "alert-warning"
+  sns_topic_critical_name         = "alert-critical"
+
+  feature_api_alarms              = true
+  api_gateway_500_error_threshold = 95
+  api_gateway_min_invocations     = 0
+  api_gateway_max_invocations     = 10000
+  api_gateway_max_latency         = 3000
+}
+
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "../../../aws//cloudwatch_alarms"
+}


### PR DESCRIPTION
Staging alarm migrated from [cds-snc/covid-alert-server-stating-terraform](https://github.com/cds-snc/covid-alert-server-stating-terraform).

This should not cause any resources to be created as everything was imported locally with the following commands:
```terraform
terragrunt import aws_cloudwatch_metric_alarm.metrics_api_gateway_500_errors_above_threshold metrics-api-gateway-errors-above-threshold
terragrunt import aws_cloudwatch_metric_alarm.metrics_api_gateway_max_invocations_threshold[0] metrics-api-gateway-above-maximum-invocations
terragrunt import aws_cloudwatch_metric_alarm.metrics_api_gateway_max_latency_threshold metrics-api-gateway-above-maximum-latency
terragrunt import aws_cloudwatch_metric_alarm.metrics_api_gateway_min_invocations_threshold metrics-api-gateway-below-minimum-invocations
```
