### PR TITLE
feat: alarms for metric traffic problems

### DIFF
--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -1,5 +1,23 @@
+# Catch "400 bad requests" when the API gateway receives an invalid metrics payload
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_400_errors_above_threshold" {
+  alarm_name          = "metrics-api-gateway-400-errors-above-threshold"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "4XXError"
+  namespace           = "AWS/ApiGateway"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = var.api_gateway_400_error_threshold
+  alarm_description   = "This metric monitors 400 errors in the metrics API gateway"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    ApiName = data.aws_api_gateway_rest_api.metrics.name
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_500_errors_above_threshold" {
-  alarm_name          = "metrics-api-gateway-errors-above-threshold"
+  alarm_name          = "metrics-api-gateway-500-errors-above-threshold"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "1"
   metric_name         = "5XXError"
@@ -67,4 +85,37 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshol
   }
 }
 
+# Alarm for a 24 hour period that checks if API traffic has changed significantly (2 standard deviations)
+resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_traffic_anomaly" {
+  count               = var.feature_api_alarms ? 1 : 0
+  alarm_name          = "metrics-api-gateway-traffic-anomaly"
+  comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
+  evaluation_periods  = "1"
+  threshold_metric_id = "daily_count_expected"
+  alarm_description   = "This metric monitors for significant changes in API gateway traffic"
+  alarm_actions       = [data.aws_sns_topic.alert_critical.arn]
+
+  metric_query {
+    id          = "daily_count_expected"
+    expression  = "ANOMALY_DETECTION_BAND(daily_count)"
+    label       = "Daily API requests (Expected)"
+    return_data = "true"
+  }
+
+  metric_query {
+    id          = "daily_count"
+    return_data = "true"
+    metric {
+      metric_name = "Count"
+      namespace   = "AWS/ApiGateway"
+      period      = "86400"
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        ApiName = data.aws_api_gateway_rest_api.metrics.name
+      }
+    }
+  }
+}
 

--- a/aws/cloudwatch_alarms/inputs.tf
+++ b/aws/cloudwatch_alarms/inputs.tf
@@ -19,6 +19,11 @@ variable "feature_api_alarms" {
   default     = true
 }
 
+variable "api_gateway_400_error_threshold" {
+  description = "Maximum sum of 4xx errors in a 60 second period before an alarm triggers"
+  type        = string
+}
+
 variable "api_gateway_500_error_threshold" {
   description = "Maximum sum of 5xx errors in a 60 second period before an alarm triggers"
   type        = string

--- a/env/production/cloudwatch_alarms/.terraform.lock.hcl
+++ b/env/production/cloudwatch_alarms/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.0"
   hashes = [
     "h1:9AUqenvmqU3Q1+iRYBRUcxyT8PCnRPy0/jFqKYucA/I=",
+    "h1:mXkfjIt8kZLnCUT3ej118IMCO6aKZgHjszO/NY4Zji8=",
     "zh:1496d971301216bfd27aada08f83315748972a50782c3c7a998212d733a8bd4f",
     "zh:3f43fd130eaf6ff82d713add40d38a526e978975e9517defabb32fe056a32371",
     "zh:52db549bf4d77235beb01c7bba72d577aa141a812cc1045a2808b40d2262fc3d",

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -4,6 +4,7 @@ inputs = {
   sns_topic_critical_name  = "alert-critical"
 
   feature_api_alarms              = true
+  api_gateway_400_error_threshold = 100
   api_gateway_500_error_threshold = 100
   api_gateway_min_invocations     = 100
   api_gateway_max_invocations     = 65000

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -4,7 +4,7 @@ inputs = {
   sns_topic_critical_name  = "alert-critical"
 
   feature_api_alarms              = true
-  api_gateway_400_error_threshold = 100
+  api_gateway_400_error_threshold = 3000
   api_gateway_500_error_threshold = 100
   api_gateway_min_invocations     = 100
   api_gateway_max_invocations     = 65000

--- a/env/staging/cloudwatch_alarms/.terraform.lock.hcl
+++ b/env/staging/cloudwatch_alarms/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.0"
   hashes = [
     "h1:9AUqenvmqU3Q1+iRYBRUcxyT8PCnRPy0/jFqKYucA/I=",
+    "h1:mXkfjIt8kZLnCUT3ej118IMCO6aKZgHjszO/NY4Zji8=",
     "zh:1496d971301216bfd27aada08f83315748972a50782c3c7a998212d733a8bd4f",
     "zh:3f43fd130eaf6ff82d713add40d38a526e978975e9517defabb32fe056a32371",
     "zh:52db549bf4d77235beb01c7bba72d577aa141a812cc1045a2808b40d2262fc3d",

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -4,6 +4,7 @@ inputs = {
   sns_topic_critical_name  = "alert-critical"
 
   feature_api_alarms              = true
+  api_gateway_400_error_threshold = 95
   api_gateway_500_error_threshold = 95
   api_gateway_min_invocations     = 0
   api_gateway_max_invocations     = 10000


### PR DESCRIPTION
# Summary
Adds two alarms related to the iOS metrics to staging incident.
1. Catch 4xx errors which can be generated by a bad metrics payload.
2. Catch traffic fluctuations from the expected daily norm.

# Expected changes
1. Two new alarms.
2. Recreate existing 5xx alarm because of name change.

Closes #71
Closes #72  