### PR TITLE
fix: alarms should deploy from tagged version

### DIFF
--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -16,5 +16,5 @@ include {
 }
 
 terraform {
-  source = "../../../aws//cloudwatch_alarms"
+  source = "git::https://github.com/cds-snc/covid-alert-metrics-terraform//aws/cloudwatch_alarms?ref=v${get_env("INFRASTRUCTURE_VERSION")}"
 }


### PR DESCRIPTION
# Description
Alarms should only be deployed to production from a tagged version of the module.  This resulted in the prod alarm being created before it was expected.

# Expected changes
1. Remove 4xx and anomaly detection alarms from prod
2. Recreate 5xx alarm with its old name

Related #71 
Related #72