### PR TITLE
fix: check prod Terragrunt config use tags

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,3 +45,6 @@ jobs:
         run: |
           cd .github/workflows/policy
           opa check *.rego
+
+      - name: Check prod Terragrunt uses tagged modules
+        run: .github/workflows/scripts/check-terragrunt-tagged.sh env/production

--- a/.github/workflows/scripts/check-terragrunt-tagged.sh
+++ b/.github/workflows/scripts/check-terragrunt-tagged.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 TERRAGRUNT_DIR=$1
-MISSING_TAGGED_MODULE=$(grep -LR "git::https://github.com/cds-snc/covid-alert-metrics-terraform//aws/" "$TERRAGRUNT_DIR"/*/terragrunt.hcl)
+MISSING_TAGGED_MODULE=$(find "$TERRAGRUNT_DIR" -maxdepth 2 -name "terragrunt.hcl" -exec grep -L "git::https://github.com/cds-snc/covid-alert-metrics-terraform//aws/" {} \;)
 
 if [[ -n "$MISSING_TAGGED_MODULE" ]]; then
     echo "ERROR - found Teragrunt configuration in \"$TERRAGRUNT_DIR\" without a tagged module:"

--- a/.github/workflows/scripts/check-terragrunt-tagged.sh
+++ b/.github/workflows/scripts/check-terragrunt-tagged.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+TERRAGRUNT_DIR=$1
+MISSING_TAGGED_MODULE=$(grep -LR "git::https://github.com/cds-snc/covid-alert-metrics-terraform//aws/" "$TERRAGRUNT_DIR"/*/terragrunt.hcl)
+
+if [[ -n "$MISSING_TAGGED_MODULE" ]]; then
+    echo "ERROR - found Teragrunt configuration in \"$TERRAGRUNT_DIR\" without a tagged module:"
+    echo "$MISSING_TAGGED_MODULE"
+    exit 1
+else
+    echo "SUCCESS - No untagged modules found in \"$TERRAGRUNT_DIR\" "
+    exit 0
+fi


### PR DESCRIPTION
# Summary
This is to catch cases that caused the incident where an untagged
module was deployed accidentally to production by a merge to main.

# Expected changes
None

Closes #82 


