### PR TITLE
fix: remove anomaly detection CloudWatch alarm

### DIFF
--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -84,38 +84,3 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_max_latency_threshol
     ApiName = data.aws_api_gateway_rest_api.metrics.name
   }
 }
-
-# Alarm for a 24 hour period that checks if API traffic has changed significantly (2 standard deviations)
-resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_traffic_anomaly" {
-  count               = var.feature_api_alarms ? 1 : 0
-  alarm_name          = "metrics-api-gateway-traffic-anomaly"
-  comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
-  evaluation_periods  = "1"
-  threshold_metric_id = "daily_count_expected"
-  alarm_description   = "This metric monitors for significant changes in API gateway traffic"
-  alarm_actions       = [data.aws_sns_topic.alert_critical.arn]
-
-  metric_query {
-    id          = "daily_count_expected"
-    expression  = "ANOMALY_DETECTION_BAND(daily_count)"
-    label       = "Daily API requests (Expected)"
-    return_data = "true"
-  }
-
-  metric_query {
-    id          = "daily_count"
-    return_data = "true"
-    metric {
-      metric_name = "Count"
-      namespace   = "AWS/ApiGateway"
-      period      = "86400"
-      stat        = "Sum"
-      unit        = "Count"
-
-      dimensions = {
-        ApiName = data.aws_api_gateway_rest_api.metrics.name
-      }
-    }
-  }
-}
-


### PR DESCRIPTION
The anomaly band AWS is calculating for the API gateway works in
Staging but for Production, it doesn't properly anticipate the UTC
midnight spike in traffic.  As a result, this alarm would trigger daily.

![image](https://user-images.githubusercontent.com/2110107/120805668-0a6f0d80-c514-11eb-9491-8831ee391d15.png)

Related #71 