### PR TITLE
fix: VPC flow log policy resource

### DIFF
--- a/aws/network/flow_logs.tf
+++ b/aws/network/flow_logs.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "vpc_metrics_flow_logs_write" {
 
     resources = [
       aws_cloudwatch_log_group.vpc_metrics_flow_logs.arn,
-      "${aws_cloudwatch_log_group.vpc_metrics_flow_logs.arn}/*"
+      "${aws_cloudwatch_log_group.vpc_metrics_flow_logs.arn}:log-stream:*"
     ]
   }
 }


### PR DESCRIPTION
# Summary
The resources for the VPC flow log IAM policy needs permission to
act on the log streams.

# Expected change
* Update IAM policy for VPC flow log

Related #92 