### PR TITLE
feat: Checkov IAM policy fixes and block S3 public access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+checkov:
+	checkov --directory=.
+
+hclfmt:
+	cd env/staging && terragrunt run-all hclfmt
+
+.PHONY: \
+	checkov \
+	hclfmt

--- a/aws/backoff_retry_lambda/iam_policies.tf
+++ b/aws/backoff_retry_lambda/iam_policies.tf
@@ -65,6 +65,7 @@ data "aws_iam_policy_document" "backoff_retry" {
       "ec2:DeleteNetworkInterface"
     ]
 
+    # checkov:skip=CKV_AWS_111::DescribeNetworkInterfaces only supports "*" resources
     resources = [
       "*"
     ]

--- a/aws/etl_lambdas/policies.tf
+++ b/aws/etl_lambdas/policies.tf
@@ -77,7 +77,10 @@ data "aws_iam_policy_document" "etl_policies" {
     ]
 
     resources = [
-      "*"
+      module.masked_metrics.log_group_arn,
+      module.unmasked_metrics.log_group_arn,
+      "${module.masked_metrics.log_group_arn}:log-stream:*",
+      "${module.unmasked_metrics.log_group_arn}:log-stream:*"
     ]
   }
 
@@ -91,6 +94,7 @@ data "aws_iam_policy_document" "etl_policies" {
       "ec2:DeleteNetworkInterface"
     ]
 
+    # checkov:skip=CKV_AWS_111:DescribeNetworkInterfaces only supports "*" resources
     resources = [
       "*"
     ]

--- a/aws/modules/s3/s3.tf
+++ b/aws/modules/s3/s3.tf
@@ -21,3 +21,12 @@ resource "aws_s3_bucket" "masked_metrics" {
   }
 
 }
+
+resource "aws_s3_bucket_public_access_block" "masked_metrics" {
+  bucket = aws_s3_bucket.masked_metrics.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
# Summary
* IAM policy updates to reference specific resources where possible.
* Block all public access to S3 buckets.
* Makefile added with common commands.

# Expected changed
1. Add two S3 public access blocks for the masked and unmasked metrics CSVs.

**Note:** the policy change was done locally during testing.

Closes #2 