### PR TITLE
fix: cpu/mem units, policy name

### DIFF
--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -14,8 +14,8 @@ resource "aws_ecs_cluster" "in_app_metrics" {
 module "masked_metrics" {
   source                       = "../modules/ecs_task"
   name                         = "masked_metrics"
-  cpu_units                    = 1
-  memory                       = 512
+  cpu_units                    = 512
+  memory                       = 1024
   task_execution_role_arn      = aws_iam_role.task_execution_role.arn
   container_execution_role_arn = aws_iam_role.container_execution_role.arn
   billing_tag_key              = var.billing_tag_key
@@ -34,8 +34,8 @@ module "masked_metrics" {
 module "unmasked_metrics" {
   source                       = "../modules/ecs_task"
   name                         = "unmasked_metrics"
-  cpu_units                    = 1
-  memory                       = 512
+  cpu_units                    = 512
+  memory                       = 1024
   container_execution_role_arn = aws_iam_role.container_execution_role.arn
   task_execution_role_arn      = aws_iam_role.task_execution_role.arn
   billing_tag_key              = var.billing_tag_key

--- a/aws/ecs/task_execution_role.tf
+++ b/aws/ecs/task_execution_role.tf
@@ -120,7 +120,7 @@ data "aws_iam_policy_document" "etl_policies" {
 }
 
 resource "aws_iam_policy" "etl_policies" {
-  name   = "EtlLambdaAccess"
+  name   = "ETLTaskExecutionPolicies"
   path   = "/"
   policy = data.aws_iam_policy_document.etl_policies.json
 }


### PR DESCRIPTION
Set the CPU units to 512 and memory to 1024 in staging (this might be changed later).
Update the name on task execution policy so it doesn't clash with existing policy (that will be removed later)
