### PR TITLE
feat: move private subnet to az that supports ECS

### DIFF
--- a/aws/network/vpc.tf
+++ b/aws/network/vpc.tf
@@ -35,8 +35,8 @@ resource "aws_subnet" "private" {
   tags = {
     Name = "${var.name}_private_subnet"
   }
-
-  cidr_block = "10.0.1.0/24"
+  availability_zone = "ca-central-1a"
+  cidr_block        = "10.0.1.0/24"
 }
 
 resource "aws_subnet" "public" {

--- a/env/staging/dynamodb/.terraform.lock.hcl
+++ b/env/staging/dynamodb/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.42.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
     "h1:quV6hK7ewiHWBznGWCb/gJ6JAPm6UtouBUrhAjv6oRY=",
     "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
     "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",

--- a/env/staging/sqs/.terraform.lock.hcl
+++ b/env/staging/sqs/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.42.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:C6/yDp6BhuDFx0qdkBuJj/OWUJpAoraHTJaU6ac38Rw=",
     "h1:quV6hK7ewiHWBznGWCb/gJ6JAPm6UtouBUrhAjv6oRY=",
     "zh:126c856a6eedddd8571f161a826a407ba5655a37a6241393560a96b8c4beca1a",
     "zh:1a4868e6ac734b5fc2e79a4a889d176286b66664aad709435aa6acee5871d5b0",


### PR DESCRIPTION
ca-central-1d does not support fargate and unforuntaly that's the AZ
that our private subnet was originally added to.

This PR will remove and recreate the private subnet, it might touch
other network resources but shouldn't affect anything outside of the
network module.

