### PR TITLE
fix: add ecs task principal to container_execution_role

### DIFF
--- a/aws/ecs/container_execution_role.tf
+++ b/aws/ecs/container_execution_role.tf
@@ -13,6 +13,11 @@ data "aws_iam_policy_document" "container_execution_role" {
       type        = "Service"
       identifiers = ["ec2.amazonaws.com"]
     }
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 

--- a/env/staging/ecs/.terraform.lock.hcl
+++ b/env/staging/ecs/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.0"
   hashes = [
     "h1:VOVZWybe1x0E4qyawTwt7jXVBRUplTrzVFHim217DqI=",
+    "h1:hxQ8n9SHHfAIXd/FtfAqxokFYWBedzZf7xqQZWJajUs=",
     "zh:0680315b29a140e9b7e4f5aeed3f2445abdfab31fc9237f34dcad06de4f410df",
     "zh:13811322a205fb4a0ee617f0ae51ec94176befdf569235d0c7064db911f0acc7",
     "zh:25e427a1cfcb1d411bc12040cf0684158d094416ecf18889a41196bacc761729",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",


### PR DESCRIPTION
This is needed so that the metrics github action can deploy images to ecs