### PR TITLE
fix: add image tag variables for ecs task

### DIFF
--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -10,7 +10,10 @@ resource "aws_ecs_cluster" "in_app_metrics" {
     (var.billing_tag_key) = var.billing_tag_value
   }
 }
-
+locals {
+  masked_metrics_image = "${var.csv_etl_repository_url}:${var.masked_image_tag}"
+  unmasked_metrics_image = "${var.csv_etl_repository_url}:${var.unmasked_image_tag}"
+}
 module "masked_metrics" {
   source                         = "../modules/ecs_task"
   name                           = "masked_metrics"
@@ -27,7 +30,7 @@ module "masked_metrics" {
   template_file                  = file("task-definitions/metrics.json")
   event_rule_schedule_expression = "rate(24 hours)"
   vars = {
-    image                 = var.csv_etl_repository_url
+    image                 = local.masked_metrics_image
     awslogs-region        = "ca-central-1"
     awslogs-stream-prefix = "ecs-masked-metrics"
     mask_data             = "True"
@@ -50,7 +53,7 @@ module "unmasked_metrics" {
   template_file                  = file("task-definitions/metrics.json")
   event_rule_schedule_expression = "rate(24 hours)"
   vars = {
-    image                 = var.csv_etl_repository_url
+    image                 = local.unmasked_metrics_image
     awslogs-region        = "ca-central-1"
     awslogs-stream-prefix = "ecs-unmasked-metrics"
     mask_data             = "False"

--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -34,6 +34,7 @@ module "masked_metrics" {
     awslogs-region        = "ca-central-1"
     awslogs-stream-prefix = "ecs-masked-metrics"
     mask_data             = "True"
+    environment           = var.env
   }
 }
 

--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_cluster" "in_app_metrics" {
   }
 }
 locals {
-  masked_metrics_image = "${var.csv_etl_repository_url}:${var.masked_image_tag}"
+  masked_metrics_image   = "${var.csv_etl_repository_url}:${var.masked_image_tag}"
   unmasked_metrics_image = "${var.csv_etl_repository_url}:${var.unmasked_image_tag}"
 }
 module "masked_metrics" {
@@ -57,5 +57,6 @@ module "unmasked_metrics" {
     awslogs-region        = "ca-central-1"
     awslogs-stream-prefix = "ecs-unmasked-metrics"
     mask_data             = "False"
+    environment           = var.env
   }
 }

--- a/aws/ecs/input.tf
+++ b/aws/ecs/input.tf
@@ -62,3 +62,15 @@ variable "billing_tag_key" {
 variable "billing_tag_value" {
   type = string
 }
+
+
+###
+# ECS Task tags
+###
+variable "masked_image_tag" {
+  type = string
+}
+
+variable "unmasked_image_tag" {
+
+}

--- a/aws/modules/ecs_task/inputs.tf
+++ b/aws/modules/ecs_task/inputs.tf
@@ -54,3 +54,11 @@ variable "vars" {
 variable "event_rule_schedule_expression" {
   type = string
 }
+
+variable "masked_image_tag" {
+  type = string
+}
+
+variable "unmasked_image_tag" {
+
+}

--- a/aws/modules/ecs_task/inputs.tf
+++ b/aws/modules/ecs_task/inputs.tf
@@ -54,11 +54,3 @@ variable "vars" {
 variable "event_rule_schedule_expression" {
   type = string
 }
-
-variable "masked_image_tag" {
-  type = string
-}
-
-variable "unmasked_image_tag" {
-
-}

--- a/env/staging/ecs/task-definitions/metrics.json
+++ b/env/staging/ecs/task-definitions/metrics.json
@@ -24,6 +24,10 @@
         {
           "name": "MASK_DATA",
           "value": "${mask_data}"
+        },
+        {
+          "name": "ENVIRONMENT",
+          "value": "${environment}"
         }
       ],
       "secrets": [

--- a/env/staging/ecs/terragrunt.hcl
+++ b/env/staging/ecs/terragrunt.hcl
@@ -51,6 +51,8 @@ inputs = {
   create_csv_repository_arn = dependency.ecr.outputs.create_csv_repository_arn
   billing_tag_key           = "CostCentre"
   billing_tag_value         = "CovidShield"
+  masked_image_tag          = "latest"
+  unmasked_image_tag        = "latest"
 }
 
 terraform {


### PR DESCRIPTION
Adds an `unmasked_image_tag` an a `masked_image_tag` to the ECS module.
This allows us to specify the images that we want to deploy.
Set image tags to latest in staging.

