### PR TITLE
fix: add bucket names to the task definition

### DIFF
--- a/aws/ecs/ecs.tf
+++ b/aws/ecs/ecs.tf
@@ -35,6 +35,7 @@ module "masked_metrics" {
     awslogs-stream-prefix = "ecs-masked-metrics"
     mask_data             = "True"
     environment           = var.env
+    bucket_name           = var.masked_metrics_bucket
   }
 }
 
@@ -59,5 +60,6 @@ module "unmasked_metrics" {
     awslogs-stream-prefix = "ecs-unmasked-metrics"
     mask_data             = "False"
     environment           = var.env
+    bucket_name           = var.unmasked_metrics_bucket
   }
 }

--- a/env/staging/ecs/task-definitions/metrics.json
+++ b/env/staging/ecs/task-definitions/metrics.json
@@ -28,6 +28,10 @@
         {
           "name": "ENVIRONMENT",
           "value": "${environment}"
+        },
+        {
+          "name": "BUCKET_NAME",
+          "value": "${bucket_name}"
         }
       ],
       "secrets": [


### PR DESCRIPTION
ECS tasks need to know the name of the bucket they are saving too.

