### PR TITLE
fix: use container exec role instead of task

### DIFF
--- a/aws/ecs/cloudwatch_event_role.tf
+++ b/aws/ecs/cloudwatch_event_role.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
   }
   statement {
     actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.task_execution_role.arn]
+    resources = [aws_iam_role.container_execution_role.arn]
   }
 }
 


### PR DESCRIPTION
Allow the etl-st-cw-role to PassRole to the container execution role instead of the task execution role.
