### PR TITLE
fix: add lambda policy dependency to vpc

### DIFF
--- a/aws/network/data_lookups.tf
+++ b/aws/network/data_lookups.tf
@@ -1,0 +1,4 @@
+
+data "aws_iam_policy" "CovidAlertBackoffRetryLambda" {
+  name = "CovidAlertBackoffRetryLambda"
+}

--- a/aws/network/vpc.tf
+++ b/aws/network/vpc.tf
@@ -37,6 +37,11 @@ resource "aws_subnet" "private" {
   }
   availability_zone = "ca-central-1a"
   cidr_block        = "10.0.1.0/24"
+
+  timeouts {
+    delete = "40m"
+  }
+  depends_on = [data.aws_iam_policy.CovidAlertBackoffRetryLambda]
 }
 
 resource "aws_subnet" "public" {


### PR DESCRIPTION
This attempts to fix the error deleting Lambda ENIs using subnet due to resource not being available during rebuild