### PR TITLE
feat: increase API gateway 5xx alarm threshold

### DIFF
--- a/aws/modules/ecs_task/cloudwatch.tf
+++ b/aws/modules/ecs_task/cloudwatch.tf
@@ -20,8 +20,14 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
     task_definition_arn = aws_ecs_task_definition.task_def.arn
 
     network_configuration {
-      subnets          = [var.subnet_id]
-      security_groups  = [var.sg_id]
+      subnets         = [var.subnet_id]
+      security_groups = [var.sg_id]
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      ecs_target[0].task_definition_arn # Updated by covid-alert-metrics workflow
+    ]
   }
 }

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -5,7 +5,7 @@ inputs = {
 
   feature_api_alarms              = true
   api_gateway_400_error_threshold = 3000
-  api_gateway_500_error_threshold = 100
+  api_gateway_500_error_threshold = 1000
   api_gateway_min_invocations     = 100
   api_gateway_max_invocations     = 65000
   api_gateway_max_latency         = 60000


### PR DESCRIPTION
# Summary
There is a new app metrics traffic pattern that is causing a
spike of save-metrics API gateway requests at midnight EST.

This is exceeding the `save-metrics` Lambda account max concurrency
and causing AWS to throttle Lambda invocations, which returns a
500 error to the phone.

Since phones will attempt to re-submitted failed metrics payloads
this means no metrics data is being lost.

# Expected change
* Increase metrics API gateway 5xx alarm threshold to 1,000.

Closes #124 