### PR TITLE
feat: add ability to manually start terraform plans from gh actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,10 +7,6 @@ on:
       - "env/**"
       - ".github/workflows/**"
   workflow_dispatch:
-    paths:
-      - "aws/**"
-      - "env/**"
-      - ".github/workflows/**"
 
 env:
   TERRAFORM_VERSION: 0.14.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,11 @@ on:
       - "aws/**"
       - "env/**"
       - ".github/workflows/**"
+  workflow_dispatch:
+    paths:
+      - "aws/**"
+      - "env/**"
+      - ".github/workflows/**"
 
 env:
   TERRAFORM_VERSION: 0.14.2


### PR DESCRIPTION
Will give the ability to launch the pull request workflow on demand.

Use case: Manually trigger terraform plan workflow steps without requiring an empty commit or finding a previous run. Allows you to select which branch to execute the workflow against