### PR TITLE
feat: increase API gateway 5xx alarm period 

### DIFF
--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_500_errors_above_thr
   evaluation_periods  = "1"
   metric_name         = "5XXError"
   namespace           = "AWS/ApiGateway"
-  period              = "60"
+  period              = "600"
   statistic           = "Sum"
   threshold           = var.api_gateway_500_error_threshold
   alarm_description   = "This metric monitors 500 errors in the metrics API gateway"

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -5,7 +5,7 @@ inputs = {
 
   feature_api_alarms              = true
   api_gateway_400_error_threshold = 95
-  api_gateway_500_error_threshold = 95
+  api_gateway_500_error_threshold = 200
   api_gateway_min_invocations     = 0
   api_gateway_max_invocations     = 10000
   api_gateway_max_latency         = 3000


### PR DESCRIPTION
# Summary
Updating the 5xx alarm period to 10 minutes.  The idea being this alarm will now catch cases were we see a large number of sustained failures, which would indicate there is an app or infrastructure problem.

# Expected change
* Staging `metrics_api_gateway_500_errors_above_threshold` alarm update.