### PR TITLE
fix: allow the passing of the new task exec role

### DIFF
--- a/aws/ecs/cloudwatch_event_role.tf
+++ b/aws/ecs/cloudwatch_event_role.tf
@@ -17,8 +17,12 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
     resources = ["*"]
   }
   statement {
-    actions   = ["iam:PassRole"]
-    resources = [aws_iam_role.task_execution_role.arn, aws_iam_role.container_execution_role.arn]
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.task_execution_role.arn,
+      aws_iam_role.container_execution_role.arn,
+      aws_iam_role.server_appstore_task_execution_role.arn
+    ]
   }
 }
 


### PR DESCRIPTION
We forgot to ad the server_appstore_task_execution_role to the passrole
policy.
