### PR TITLE
feat: CloudWatch alarm for change in traffic

### DIFF
--- a/aws/cloudwatch_alarms/inputs.tf
+++ b/aws/cloudwatch_alarms/inputs.tf
@@ -43,3 +43,8 @@ variable "api_gateway_max_latency" {
   description = "Maximum latency (milliseconds) in a 60 second period before an alarm triggers"
   type        = string
 }
+
+variable "api_gateway_traffic_change_percent" {
+  description = "Maximum traffic percentage change between current and previous day"
+  type        = string
+}

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -3,12 +3,13 @@ inputs = {
   sns_topic_warning_name   = "alert-warning"
   sns_topic_critical_name  = "alert-critical"
 
-  feature_api_alarms              = true
-  api_gateway_400_error_threshold = 3000
-  api_gateway_500_error_threshold = 1000
-  api_gateway_min_invocations     = 100
-  api_gateway_max_invocations     = 65000
-  api_gateway_max_latency         = 60000
+  feature_api_alarms                 = true
+  api_gateway_400_error_threshold    = 3000
+  api_gateway_500_error_threshold    = 1000
+  api_gateway_min_invocations        = 100
+  api_gateway_max_invocations        = 65000
+  api_gateway_max_latency            = 60000
+  api_gateway_traffic_change_percent = 20
 }
 
 include {

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -3,12 +3,13 @@ inputs = {
   sns_topic_warning_name   = "alert-warning"
   sns_topic_critical_name  = "alert-critical"
 
-  feature_api_alarms              = true
-  api_gateway_400_error_threshold = 95
-  api_gateway_500_error_threshold = 200
-  api_gateway_min_invocations     = 0
-  api_gateway_max_invocations     = 10000
-  api_gateway_max_latency         = 3000
+  feature_api_alarms                 = true
+  api_gateway_400_error_threshold    = 95
+  api_gateway_500_error_threshold    = 200
+  api_gateway_min_invocations        = 0
+  api_gateway_max_invocations        = 10000
+  api_gateway_max_latency            = 3000
+  api_gateway_traffic_change_percent = 20
 }
 
 include {


### PR DESCRIPTION
# Summary
Testing an alarm that will trigger when there is more than a 20% traffic change between 2 days.  Currently it does not notify of alarm conditions.

# Expected change
New CloudWatch alarm.

Closes #71 