### PR TITLE
fix: retrieve metrics_token secret value from github secrets

### DIFF
--- a/.github/workflows/apply-staging.yml
+++ b/.github/workflows/apply-staging.yml
@@ -18,6 +18,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
+      TF_VAR_METRICS_TOKEN: ${{ secrets.STAGING_METRICS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -154,6 +154,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}      
+          TF_VAR_METRICS_TOKEN: ${{ secrets[format('{0}_METRICS_TOKEN',matrix.environment)] }}
         uses: cds-snc/terraform-plan@v1.0.4
         with:
           directory: "env/${{ matrix.environment }}/${{ matrix.module_name }}"

--- a/aws/ecs/inputs.tf
+++ b/aws/ecs/inputs.tf
@@ -140,3 +140,7 @@ variable "aggregate_metrics_table_arn" {
 variable "schedule_expression" {
   type = string
 }
+
+variable "metrics_token" {
+  type = string
+}

--- a/aws/ecs/secretsmanager_role.tf
+++ b/aws/ecs/secretsmanager_role.tf
@@ -1,3 +1,8 @@
+resource "aws_secretsmanager_secret_version" "metrics_token" {
+  secret_id     = aws_secretsmanager_secret.metrics_token.id
+  secret_string = var.metrics_token
+}
+
 resource "aws_iam_role" "secretsmanager_role" {
   name               = "metrics_secretsmanager_role"
   assume_role_policy = data.aws_iam_policy_document.task_execution_role.json

--- a/env/staging/ecs/task-definitions/server_metrics.json
+++ b/env/staging/ecs/task-definitions/server_metrics.json
@@ -37,11 +37,9 @@
           "value": "${bucket_name}"
         }
       ],
-      "containerDefinitions": [{
-        "secrets": [{
-          "name": "metrics_token",
-          "valueFrom": "${metric_token_secret_arn}"
-        }]
+      "secrets": [{
+        "name": "metrics_token",
+        "valueFrom": "${metric_token_secret_arn}"
       }],
       "essential": true,
       "mountPoints": [],

--- a/env/staging/ecs/terragrunt.hcl
+++ b/env/staging/ecs/terragrunt.hcl
@@ -69,6 +69,7 @@ inputs = {
   memory                              = 1024
   aggregate_metrics_table_arn         = dependency.dynamodb.outputs.aggregate_metrics_arn
   schedule_expression                 = "rate(24 hours)"
+  metrics_token                       = "${get_env("TF_VAR_METRICS_TOKEN")}"
 }
 
 terraform {


### PR DESCRIPTION
Fixes #142 