### PR TITLE
fix: TG will now automatically inject metrics_token from secrets. 

### DIFF
--- a/.github/workflows/apply-production.yml
+++ b/.github/workflows/apply-production.yml
@@ -17,6 +17,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
+      TF_VAR_metrics_token: ${{ secrets.PRODUCTION_METRICS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/apply-staging.yml
+++ b/.github/workflows/apply-staging.yml
@@ -18,7 +18,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
-      TF_VAR_METRICS_TOKEN: ${{ secrets.STAGING_METRICS_TOKEN }}
+      TF_VAR_metrics_token: ${{ secrets.STAGING_METRICS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -154,7 +154,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}      
-          TF_VAR_METRICS_TOKEN: ${{ secrets[format('{0}_METRICS_TOKEN',matrix.environment)] }}
+          TF_VAR_metrics_token: ${{ secrets[format('{0}_METRICS_TOKEN',matrix.environment)] }}
         uses: cds-snc/terraform-plan@v1.0.4
         with:
           directory: "env/${{ matrix.environment }}/${{ matrix.module_name }}"

--- a/env/production/ecs/task-definitions/server_metrics.json
+++ b/env/production/ecs/task-definitions/server_metrics.json
@@ -1,0 +1,48 @@
+[
+    {
+      "name": "${name}",
+      "image": "${image}",
+      "portMappings": [
+        {
+          "hostPort": 8001,
+          "protocol": "tcp",
+          "containerPort": 8001
+        }
+      ],
+      "linuxParameters": {
+        "capabilities": {
+          "drop": ["ALL"]
+        }
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "${awslogs-group}",
+          "awslogs-region": "${awslogs-region}",
+          "awslogs-stream-prefix": "${awslogs-stream-prefix}"
+        }
+      },
+      "cpu": 0,
+      "environment": [
+        {
+          "name": "MASK_DATA",
+          "value": "${mask_data}"
+        },
+        {
+          "name": "ENVIRONMENT",
+          "value": "${environment}"
+        },
+        {
+          "name": "BUCKET_NAME",
+          "value": "${bucket_name}"
+        }
+      ],
+      "secrets": [{
+        "name": "metrics_token",
+        "valueFrom": "${metric_token_secret_arn}"
+      }],
+      "essential": true,
+      "mountPoints": [],
+      "volumesFrom": []
+    }
+  ]

--- a/env/staging/ecs/terragrunt.hcl
+++ b/env/staging/ecs/terragrunt.hcl
@@ -69,7 +69,6 @@ inputs = {
   memory                              = 1024
   aggregate_metrics_table_arn         = dependency.dynamodb.outputs.aggregate_metrics_arn
   schedule_expression                 = "rate(24 hours)"
-  metrics_token                       = "${get_env("TF_VAR_METRICS_TOKEN")}"
 }
 
 terraform {


### PR DESCRIPTION
- TG will now automatically inject metrics_token from github secrets. 
- PR ECS now also contains the new taskdefinition

fixes #145 