### PR TITLE
fix: attach ReadSecrets policy to container exec

### DIFF
--- a/aws/ecs/cloudwatch_event_role.tf
+++ b/aws/ecs/cloudwatch_event_role.tf
@@ -21,8 +21,7 @@ data "aws_iam_policy_document" "scheduled_task_cw_event_role_cloudwatch_policy" 
     resources = [
       aws_iam_role.task_execution_role.arn,
       aws_iam_role.container_execution_role.arn,
-      aws_iam_role.server_appstore_task_execution_role.arn,
-      aws_iam_role.server_metrics_task_execution_role.arn
+      aws_iam_role.server_appstore_task_execution_role.arn
     ]
   }
 }

--- a/aws/ecs/server_metrics_etl.tf
+++ b/aws/ecs/server_metrics_etl.tf
@@ -9,7 +9,7 @@ module "masked_server_metrics_etl" {
   cpu_units                      = var.server_metrics_cpu_units
   memory                         = var.server_metrics_memory
   container_execution_role_arn   = aws_iam_role.container_execution_role.arn
-  task_execution_role_arn        = aws_iam_role.server_metrics_task_execution_role.arn
+  task_execution_role_arn        = aws_iam_role.server_appstore_task_execution_role.arn
   scheduled_task_role_arn        = aws_iam_role.scheduled_task_cw_event_role.arn
   billing_tag_key                = var.billing_tag_key
   billing_tag_value              = var.billing_tag_value
@@ -36,7 +36,7 @@ module "unmasked_server_metrics_etl" {
   cpu_units                      = var.server_metrics_cpu_units
   memory                         = var.server_metrics_memory
   container_execution_role_arn   = aws_iam_role.container_execution_role.arn
-  task_execution_role_arn        = aws_iam_role.server_metrics_task_execution_role.arn
+  task_execution_role_arn        = aws_iam_role.server_appstore_task_execution_role.arn
   scheduled_task_role_arn        = aws_iam_role.scheduled_task_cw_event_role.arn
   billing_tag_key                = var.billing_tag_key
   billing_tag_value              = var.billing_tag_value

--- a/aws/ecs/task_execution_policy_documents.tf
+++ b/aws/ecs/task_execution_policy_documents.tf
@@ -32,19 +32,6 @@ data "aws_iam_policy_document" "task_execution_role" {
   }
 }
 
-data "aws_iam_policy_document" "server_metrics_task_execution_role" {
-  statement {
-    effect = "Allow"
-
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
-    }
-  }
-}
-
 data "aws_iam_policy_document" "etl_policies" {
 
   statement {

--- a/aws/ecs/task_execution_policy_documents.tf
+++ b/aws/ecs/task_execution_policy_documents.tf
@@ -134,11 +134,3 @@ data "aws_iam_policy_document" "etl_policies" {
   }
 
 }
-
-data "aws_iam_policy_document" "get_metrics_token_secret_value_ecs_task" {
-  statement {
-    effect    = "Allow"
-    actions   = ["secretsmanager:GetSecretValue"]
-    resources = [aws_secretsmanager_secret.metrics_token.arn]
-  }
-}

--- a/aws/ecs/task_execution_roles.tf
+++ b/aws/ecs/task_execution_roles.tf
@@ -18,27 +18,8 @@ resource "aws_iam_role_policy_attachment" "readonly_table_te_etl_policies" {
   policy_arn = aws_iam_policy.readonly_aggregate_metrics.arn
 }
 
-
 ###
-# Server metrics Task Execution Role
-###
-resource "aws_iam_role" "server_metrics_task_execution_role" {
-  name               = "server_metrics_task_execution_role"
-  assume_role_policy = data.aws_iam_policy_document.server_metrics_task_execution_role.json
-}
-
-resource "aws_iam_role_policy_attachment" "server_metrics_te_etl_policies" {
-  role       = aws_iam_role.server_metrics_task_execution_role.name
-  policy_arn = aws_iam_policy.etl_policies.arn
-}
-
-resource "aws_iam_role_policy_attachment" "secretsmanager_etl_policies" {
-  role       = aws_iam_role.server_metrics_task_execution_role.name
-  policy_arn = aws_iam_policy.get_metrics_token_secret_value_ecs_task.arn
-}
-
-###
-# Appstore metrics Task Execution Role
+# Appstore & Server metrics Task Execution Role
 ###
 resource "aws_iam_role" "server_appstore_task_execution_role" {
   name               = "server_appstore_metrics_task_execution_role"


### PR DESCRIPTION
Remove the Server_metrics role and replace with the old server_appstore
role

Attach the secretsmanager_etl_policies to a new container exec role for
the server metrics task

