### PR TITLE
Send error metrics to cloudwatch metrics and generation alarms

### DIFF
--- a/aws/aggregate_metrics_lambda/iam_policies.tf
+++ b/aws/aggregate_metrics_lambda/iam_policies.tf
@@ -41,6 +41,11 @@ resource "aws_iam_role_policy_attachment" "aggregator_write_and_encrypt_deadlett
   policy_arn = aws_iam_policy.write_and_encrypt_deadletter_queue.arn
 }
 
+resource "aws_iam_role_policy_attachment" "aggregator_write_cloudwatch_metrics" {
+  role       = aws_iam_role.aggregator.name
+  policy_arn = aws_iam_policy.write_cloudwatch_metrics.arn
+}
+
 data "aws_iam_policy_document" "aggregate_metrics_update" {
   statement {
     effect = "Allow"
@@ -162,4 +167,23 @@ resource "aws_iam_policy" "write_and_encrypt_deadletter_queue" {
   name   = "CovidAlertWriteAndEncryptDeadletterQueue"
   path   = "/"
   policy = data.aws_iam_policy_document.write_and_encrypt_deadletter_queue.json
+}
+
+# Write CloudWatch metrics
+
+data "aws_iam_policy_document" "write_cloudwatch_metrics" {
+  statement {
+
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "write_cloudwatch_metrics" {
+  name   = "CovidAlertWriteCloudwatchMetrics"
+  path   = "/"
+  policy = data.aws_iam_policy_document.write_cloudwatch_metrics.json
 }

--- a/aws/cloudwatch_alarms/error_metrics.tf
+++ b/aws/cloudwatch_alarms/error_metrics.tf
@@ -1,0 +1,34 @@
+# Catch "QR parse errors" from the covid alert app
+resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_critical_threshold" {
+  alarm_name          = "metrics-app-errors-500-qr-parse-above-critical-threshold"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "CovidAlertApp"
+  period              = "86400"
+  statistic           = "Sum"
+  threshold           = var.app_500_qr_parse_error_critical_threshold
+  alarm_description   = "This metric monitors error-500-qr-parse errors in the covid alert app"
+
+  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  dimensions = {
+    Identifier = "error-500-qr-parse"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_warning_threshold" {
+  alarm_name          = "metrics-app-errors-500-qr-parse-above-warning-threshold"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Errors"
+  namespace           = "CovidAlertApp"
+  period              = "86400"
+  statistic           = "Sum"
+  threshold           = var.app_500_qr_parse_error_warning_threshold
+  alarm_description   = "This metric monitors error-500-qr-parse errors in the covid alert app"
+
+  alarm_actions = [data.aws_sns_topic.alert_warning.arn]
+  dimensions = {
+    Identifier = "error-500-qr-parse"
+  }
+}

--- a/aws/cloudwatch_alarms/inputs.tf
+++ b/aws/cloudwatch_alarms/inputs.tf
@@ -48,3 +48,13 @@ variable "api_gateway_traffic_change_percent" {
   description = "Maximum traffic percentage change between current and previous day"
   type        = string
 }
+
+variable "app_500_qr_parse_error_critical_threshold" {
+  description = "Maximum sum of QR parse errors in a 24 hour period before a critical alarm triggers"
+  type        = string
+}
+
+variable "app_500_qr_parse_error_warning_threshold" {
+  description = "Maximum sum of QR parse errors in a 24 hour period before a warning alarm triggers"
+  type        = string
+}

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -3,13 +3,15 @@ inputs = {
   sns_topic_warning_name   = "alert-warning"
   sns_topic_critical_name  = "alert-critical"
 
-  feature_api_alarms                 = true
-  api_gateway_400_error_threshold    = 3000
-  api_gateway_500_error_threshold    = 1000
-  api_gateway_min_invocations        = 100
-  api_gateway_max_invocations        = 65000
-  api_gateway_max_latency            = 60000
-  api_gateway_traffic_change_percent = 20
+  feature_api_alarms                        = true
+  api_gateway_400_error_threshold           = 3000
+  api_gateway_500_error_threshold           = 1000
+  api_gateway_min_invocations               = 100
+  api_gateway_max_invocations               = 65000
+  api_gateway_max_latency                   = 60000
+  api_gateway_traffic_change_percent        = 20
+  app_500_qr_parse_error_critical_threshold = 3
+  app_500_qr_parse_error_warning_threshold  = 1
 }
 
 include {

--- a/env/staging/aggregate_metrics_lambda/lambda/aggregate_values.test.js
+++ b/env/staging/aggregate_metrics_lambda/lambda/aggregate_values.test.js
@@ -14,12 +14,18 @@ jest.mock("aws-sdk", () => {
     promise: jest.fn(),
   };
 
+  const mockCloudWatch = {
+    putMetricData: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  };
+
   return {
     __esModule: true,
     DynamoDB: {
       DocumentClient: jest.fn(() => mockDynamoDb)
     },
     SQS: jest.fn(() => mockSQS),
+    CloudWatch: jest.fn(() => mockCloudWatch),
   };
 });
 
@@ -652,6 +658,22 @@ describe("sendToDeadLetterQueue", () => {
     let err = "ouch"
     lambda.sendToDeadLetterQueue(payload, err)
     expect(sqs.sendMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("writeCloudWatchMetric", () => {
+  let cloudwatch
+
+  beforeAll(async (done) => {
+    cloudwatch = new AWS.CloudWatch()
+    done();
+  });
+
+  it("writes a metric", () => {
+    let metric = {a: true}
+    let err = "ouch"
+    lambda.writeCloudWatchMetric(metric, err)
+    expect(cloudwatch.putMetricData).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -3,13 +3,15 @@ inputs = {
   sns_topic_warning_name   = "alert-warning"
   sns_topic_critical_name  = "alert-critical"
 
-  feature_api_alarms                 = true
-  api_gateway_400_error_threshold    = 95
-  api_gateway_500_error_threshold    = 200
-  api_gateway_min_invocations        = 0
-  api_gateway_max_invocations        = 10000
-  api_gateway_max_latency            = 3000
-  api_gateway_traffic_change_percent = 20
+  feature_api_alarms                        = true
+  api_gateway_400_error_threshold           = 95
+  api_gateway_500_error_threshold           = 200
+  api_gateway_min_invocations               = 0
+  api_gateway_max_invocations               = 10000
+  api_gateway_max_latency                   = 3000
+  api_gateway_traffic_change_percent        = 20
+  app_500_qr_parse_error_critical_threshold = 3
+  app_500_qr_parse_error_warning_threshold  = 1
 }
 
 include {


### PR DESCRIPTION
aggregate_metrics lambda will now send error metrics to cloudwatch. This PR will create a new metric alarm based on the below

3 occurrences of error-500-qr-parse will generate a critical alarm
1 occurrences of error-500-qr-parse will generate a warning alarm

Closes #153 