### PR TITLE
fix: use API gateway "Count" metric

### DIFF
--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -97,7 +97,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_traffic_change" {
     label = "Current count"
 
     metric {
-      metric_name = "RequestCount"
+      metric_name = "Count"
       namespace   = "AWS/ApiGateway"
       period      = "86400"
       stat        = "Sum"


### PR DESCRIPTION
# Summary
Update traffic change alarm to use API gateway's `Count` metric.

# Expected change
Update the CloudWatch alarm.

Related #71 