### PR TITLE
fix: container execution role

### DIFF
--- a/aws/ecs/server_metrics_etl.tf
+++ b/aws/ecs/server_metrics_etl.tf
@@ -8,7 +8,7 @@ module "masked_server_metrics_etl" {
   name                           = "masked_server_metrics"
   cpu_units                      = var.server_metrics_cpu_units
   memory                         = var.server_metrics_memory
-  container_execution_role_arn   = aws_iam_role.container_execution_role.arn
+  container_execution_role_arn   = aws_iam_role.server_metrics_container_execution_role.arn
   task_execution_role_arn        = aws_iam_role.server_appstore_task_execution_role.arn
   scheduled_task_role_arn        = aws_iam_role.scheduled_task_cw_event_role.arn
   billing_tag_key                = var.billing_tag_key
@@ -36,7 +36,7 @@ module "unmasked_server_metrics_etl" {
   name                           = "unmasked_server_metrics"
   cpu_units                      = var.server_metrics_cpu_units
   memory                         = var.server_metrics_memory
-  container_execution_role_arn   = aws_iam_role.container_execution_role.arn
+  container_execution_role_arn   = aws_iam_role.server_metrics_container_execution_role.arn
   task_execution_role_arn        = aws_iam_role.server_appstore_task_execution_role.arn
   scheduled_task_role_arn        = aws_iam_role.scheduled_task_cw_event_role.arn
   billing_tag_key                = var.billing_tag_key


### PR DESCRIPTION
Set the proper container execution role for the server metrics task so
it can access the metrics_token secret

