### PR TITLE
feat: metric traffic change alarm warning action

### DIFF
--- a/aws/cloudwatch_alarms/api_gateway.tf
+++ b/aws/cloudwatch_alarms/api_gateway.tf
@@ -91,6 +91,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_api_gateway_traffic_change" {
   evaluation_periods  = "1"
   threshold           = var.api_gateway_traffic_change_percent
   alarm_description   = "Maximum traffic percentage change between current and previous day"
+  alarm_actions       = [data.aws_sns_topic.alert_warning.arn]
 
   metric_query {
     id    = "current"


### PR DESCRIPTION
# Summary
A 20% change in traffic over 2 days will now trigger an alarm. This is meant to catch cases where suddenly a large number
of phones stop sending us data.

# Expected change
Add warning alarm action.

Closes #168 