### PR TITLE
fix: remove host_path and enable ptrace

### DIFF
--- a/aws/modules/ecs_task/task.tf
+++ b/aws/modules/ecs_task/task.tf
@@ -16,27 +16,22 @@ resource "aws_ecs_task_definition" "task_def" {
 
   volume {
     name = "dev-fs"
-    host_path = "/dev"
   }
 
   volume {
     name = "proc-fs"
-    host_path = "/proc"
   }
 
   volume {
     name = "boot-fs"
-    host_path = "/boot"
   }
 
   volume {
     name = "lib-modules"
-    host_path = "/lib/modules"
   }
 
   volume {
     name = "usr-fs"
-    host_path = "/usr"
   }
 
   tags = {

--- a/env/staging/ecs/task-definitions/metrics.json
+++ b/env/staging/ecs/task-definitions/metrics.json
@@ -11,7 +11,8 @@
       ],
       "linuxParameters": {
         "capabilities": {
-          "drop": ["ALL"]
+          "drop": ["ALL"],
+          "add": ["SYS_PTRACE"]
         }
       },
       "logConfiguration": {

--- a/env/staging/ecs/task-definitions/server_metrics.json
+++ b/env/staging/ecs/task-definitions/server_metrics.json
@@ -11,7 +11,8 @@
       ],
       "linuxParameters": {
         "capabilities": {
-          "drop": ["ALL"]
+          "drop": ["ALL"],
+          "add": ["SYS_PTRACE"]
         }
       },
       "logConfiguration": {


### PR DESCRIPTION
Fargate does not allow you to specify the host or sourcePath for a bind mount
Also enabling ptrace support since falco requires it when running on fargate