### PR TITLE
fix: reintroduce ecs volume and remove missed host_path

### DIFF
--- a/aws/modules/ecs_task/task.tf
+++ b/aws/modules/ecs_task/task.tf
@@ -9,6 +9,30 @@ resource "aws_ecs_task_definition" "task_def" {
   task_role_arn            = var.task_execution_role_arn
   container_definitions    = data.template_file.masked_metrics.rendered
 
+  volume {
+    name = "docker-socket"
+  }
+
+  volume {
+    name = "dev-fs"
+  }
+
+  volume {
+    name = "proc-fs"
+  }
+
+  volume {
+    name = "boot-fs"
+  }
+
+  volume {
+    name = "lib-modules"
+  }
+
+  volume {
+    name = "usr-fs"
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }


### PR DESCRIPTION
This failed last time because i didn't notice two volumes still declared a host_path. Hopefully this fixes the volume issues.