### PR TITLE
chore: remove elevated container priviledges

### DIFF
--- a/env/staging/ecs/task-definitions/metrics.json
+++ b/env/staging/ecs/task-definitions/metrics.json
@@ -60,7 +60,6 @@
       "essential": true,
       "cpu": 10,
       "memory": 512,
-      "privileged": true,
       "command": [
         "/usr/bin/falco",
         "-pc",

--- a/env/staging/ecs/task-definitions/server_metrics.json
+++ b/env/staging/ecs/task-definitions/server_metrics.json
@@ -67,7 +67,6 @@
       "essential": true,
       "cpu": 10,
       "memory": 512,
-      "privileged": true,
       "command": [
         "/usr/bin/falco",
         "-pc",


### PR DESCRIPTION
Missing link to get falco running that was verified via click ops