### PR TITLE
chore: use v1 release of Terrafom plan action

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -87,7 +87,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}      
-        uses: cds-snc/terraform-plan@v1.0.4
+        uses: cds-snc/terraform-plan@v1
         with:
           directory: "env/${{ matrix.environment }}/${{ matrix.module_name }}"
           comment-delete: "true"
@@ -155,7 +155,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}      
           TF_VAR_metrics_token: ${{ secrets[format('{0}_METRICS_TOKEN',matrix.environment)] }}
-        uses: cds-snc/terraform-plan@v1.0.4
+        uses: cds-snc/terraform-plan@v1
         with:
           directory: "env/${{ matrix.environment }}/${{ matrix.module_name }}"
           comment-delete: "true"


### PR DESCRIPTION
# Summary
This will keep the CI updated with the latest non-breaking version of the action.