### PR TITLE
feat: use Alpine base image for ECS metrics tasks

### DIFF
--- a/env/production/ecs/terragrunt.hcl
+++ b/env/production/ecs/terragrunt.hcl
@@ -49,7 +49,7 @@ inputs = {
   # Server Metrics Inputs
   server_metrics_etl_repository_url   = dependency.ecr.outputs.server_metrics_etl_repository_url
   server_metrics_etl_repository_arn   = dependency.ecr.outputs.server_metrics_etl_repository_arn
-  server_tag                          = "23d26c3080824c108aee1e83701fc2fc4796cb5e"
+  server_tag                          = "57834e8915ec0fca47219887b948a0cb08a9c732"
   masked_server_schedule_expression   = "cron(0 5 * * ? *)"
   unmasked_server_schedule_expression = "cron(0 5 * * ? *)"
   server_events_endpoint              = "https://retrieval.covid-notification.alpha.canada.ca/events"
@@ -57,14 +57,14 @@ inputs = {
   # Appstore Metrics Inputs
   appstore_metrics_etl_repository_url   = dependency.ecr.outputs.appstore_metrics_etl_repository_url
   appstore_metrics_etl_repository_arn   = dependency.ecr.outputs.appstore_metrics_etl_repository_arn
-  appstore_tag                          = "23d26c3080824c108aee1e83701fc2fc4796cb5e"
+  appstore_tag                          = "57834e8915ec0fca47219887b948a0cb08a9c732"
   masked_appstore_schedule_expression   = "cron(0 5 * * ? *)"
   unmasked_appstore_schedule_expression = "cron(0 5 * * ? *)"
 
   # Inapp Metrics Inputs
   inapp_metrics_etl_repository_url   = dependency.ecr.outputs.inapp_metrics_etl_repository_url
   inapp_metrics_etl_repository_arn   = dependency.ecr.outputs.inapp_metrics_etl_repository_arn
-  inapp_tag                          = "23d26c3080824c108aee1e83701fc2fc4796cb5e"
+  inapp_tag                          = "57834e8915ec0fca47219887b948a0cb08a9c732"
   inapp_metrics_cpu_units            = 2048
   inapp_metrics_memory               = 16384
   masked_inapp_schedule_expression   = "cron(0 3 * * ? *)"


### PR DESCRIPTION
# Summary
This switches the ECS app, server and appstore metric ETL tasks
to use the Alpine base Docker image.