### PR TITLE
chore: bump falco to master branch

### DIFF
--- a/env/staging/ecs/task-definitions/metrics.json
+++ b/env/staging/ecs/task-definitions/metrics.json
@@ -73,7 +73,7 @@
 		],
 		"cpu": 10,
 		"essential": true,
-		"image": "falcosecurity/falco:0.17.1",
+		"image": "falcosecurity/falco:master",
 		"logConfiguration": {
 			"logDriver": "awsfirelens",
 			"options": {

--- a/env/staging/ecs/task-definitions/server_metrics.json
+++ b/env/staging/ecs/task-definitions/server_metrics.json
@@ -83,7 +83,7 @@
 		],
 		"cpu": 10,
 		"essential": true,
-		"image": "falcosecurity/falco:0.17.1",
+		"image": "falcosecurity/falco:master",
 		"logConfiguration": {
 			"logDriver": "awsfirelens",
 			"options": {


### PR DESCRIPTION
This is required since latest kernel headers are only available in this branch