### PR TITLE
chore: restore original api name

### DIFF
--- a/env/staging/api_gateway/terragrunt.hcl
+++ b/env/staging/api_gateway/terragrunt.hcl
@@ -9,9 +9,14 @@ inputs = {
   api_gateway_burst = "5000"
   billing_tag_key   = "CostCentre"
   billing_tag_value = "CovidShield"
-  service_name      = "create_metrics"
 }
 
 terraform {
   source = "../../../aws//api_gateway"
+  extra_arguments "extra_args" {
+    commands = "${get_terraform_commands_that_need_vars()}"
+    optional_var_files = [
+      "${find_in_parent_folders("variables.auto.tfvars", "ignore")}",
+    ]
+  }
 }

--- a/env/staging/create_metrics_lambda/terragrunt.hcl
+++ b/env/staging/create_metrics_lambda/terragrunt.hcl
@@ -53,8 +53,6 @@ inputs = {
   resource_id           = dependency.api_gateway.outputs.resource_id
   http_method           = dependency.api_gateway.outputs.http_method
 
-  service_name = "create_metrics"
-
   feature_count_alarms            = true
   create_metrics_max_avg_duration = 10000
   create_metrics_dynamodb_wcu_max = 300
@@ -62,4 +60,10 @@ inputs = {
 
 terraform {
   source = "../../../aws//create_metrics_lambda"
+  extra_arguments "extra_args" {
+    commands = "${get_terraform_commands_that_need_vars()}"
+    optional_var_files = [
+      "${find_in_parent_folders("variables.auto.tfvars", "ignore")}",
+    ]
+  }
 }

--- a/env/variables.auto.tfvars
+++ b/env/variables.auto.tfvars
@@ -1,1 +1,1 @@
-service_name = "create_metrics"
+service_name = "save-metrics"


### PR DESCRIPTION
Having API stage and resource with different endpoints (create_metrics vs save-metrics) is too risky. Restoring the path back to "save-metrics"