### PR TITLE
fix: lambda execution role has correct permissions

### DIFF
--- a/aws/create_metrics_lambda/iam_policies.tf
+++ b/aws/create_metrics_lambda/iam_policies.tf
@@ -21,14 +21,15 @@ resource "aws_iam_role_policy_attachment" "createmetrics_dynamodb_put" {
   policy_arn = aws_iam_policy.create_metrics_put.arn
 }
 
-resource "aws_iam_role_policy_attachment" "create_metrics_log_writer" {
+# Use AWS managed IAM policy
+####
+# Provides minimum permissions for a Lambda function to execute while 
+# accessing a resource within a VPC - create, describe, delete network 
+# interfaces and write permissions to CloudWatch Logs.
+####
+resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
   role       = aws_iam_role.create_metrics.name
-  policy_arn = aws_iam_policy.write_logs.arn
-}
-
-resource "aws_iam_role_policy_attachment" "createmetrics_vpc_networking" {
-  role       = aws_iam_role.create_metrics.name
-  policy_arn = aws_iam_policy.vpc_networking.arn
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 # create_metrics_put
@@ -52,54 +53,4 @@ resource "aws_iam_policy" "create_metrics_put" {
   name   = "CovidAlertCreateMetricsPutItem"
   path   = "/"
   policy = data.aws_iam_policy_document.create_metrics_put.json
-}
-
-# write_logs
-
-data "aws_iam_policy_document" "write_logs" {
-  statement {
-
-    effect = "Allow"
-
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-
-    resources = [
-      "arn:aws:logs:*:*:*"
-    ]
-  }
-}
-
-resource "aws_iam_policy" "write_logs" {
-  name   = "CovidAlertLogWriter"
-  path   = "/"
-  policy = data.aws_iam_policy_document.write_logs.json
-}
-
-# vpc_networking
-
-data "aws_iam_policy_document" "vpc_networking" {
-  statement {
-
-    effect = "Allow"
-
-    actions = [
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DeleteNetworkInterface"
-    ]
-
-    resources = [
-      "arn:aws:ec2:${var.region}:${var.account_id}:network-interface/*"
-    ]
-
-  }
-}
-
-resource "aws_iam_policy" "vpc_networking" {
-  name   = "CovidAlertVplNetworking"
-  path   = "/"
-  policy = data.aws_iam_policy_document.vpc_networking.json
 }


### PR DESCRIPTION
AWS managed policy was missing that defines the minimum required to run lambdas. This has been added and the unnecessary customer managed policies have been removed since they're not redundant.