### PR TITLE
feat: set API gateway route53 zone name with input

### DIFF
--- a/.github/workflows/apply-production.yml
+++ b/.github/workflows/apply-production.yml
@@ -18,7 +18,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
       TF_VAR_metrics_token: ${{ secrets.PRODUCTION_METRICS_TOKEN }}
-      TF_VAR_route53_zone_name: ${{ secrets.PRODUCTION_ROUTE53_ZONE_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/apply-staging.yml
+++ b/.github/workflows/apply-staging.yml
@@ -19,7 +19,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ca-central-1
       TF_VAR_metrics_token: ${{ secrets.STAGING_METRICS_TOKEN }}
-      TF_VAR_route53_zone_name: ${{ secrets.STAGING_ROUTE53_ZONE_NAME }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,7 +93,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID',matrix.environment)] }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY',matrix.environment)] }}      
-          TF_VAR_route53_zone_name: ${{ secrets[format('{0}_ROUTE53_ZONE_NAME',matrix.environment)] }}
         uses: cds-snc/terraform-plan@v1
         with:
           directory: "env/${{ matrix.environment }}/${{ matrix.module_name }}"

--- a/env/production/api_gateway/terragrunt.hcl
+++ b/env/production/api_gateway/terragrunt.hcl
@@ -9,6 +9,7 @@ inputs = {
   api_gateway_burst = "5000"
   billing_tag_key   = "CostCentre"
   billing_tag_value = "CovidShield"
+  route53_zone_name = "covid-notification.alpha.canada.ca"
 }
 
 terraform {

--- a/env/staging/api_gateway/terragrunt.hcl
+++ b/env/staging/api_gateway/terragrunt.hcl
@@ -9,6 +9,7 @@ inputs = {
   api_gateway_burst = "5000"
   billing_tag_key   = "CostCentre"
   billing_tag_value = "CovidShield"
+  route53_zone_name = "wild-samphire.cdssandbox.xyz"
 }
 
 terraform {


### PR DESCRIPTION
# Summary

The Route53 hosted zone name is not secret and can be set as a plaintext input to the `api_gateway` module.

Related #148 