### PR TITLE
feat: set QR parse error alarm to warning topic

### DIFF
--- a/aws/cloudwatch_alarms/error_metrics.tf
+++ b/aws/cloudwatch_alarms/error_metrics.tf
@@ -10,9 +10,9 @@ resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_cr
   namespace           = "CovidAlertApp"
   statistic           = "Sum"
   threshold           = var.app_500_qr_parse_error_critical_threshold
-  alarm_description   = "This metric monitors error-500-qr-parse errors in the covid alert app and generates a critical alarm"
+  alarm_description   = "This metric monitors error-500-qr-parse errors in the covid alert app and generates a warning alarm"
 
-  alarm_actions = [data.aws_sns_topic.alert_critical.arn]
+  alarm_actions = [data.aws_sns_topic.alert_warning.arn]
   dimensions = {
     Identifier = "error-500-qr-parse"
   }


### PR DESCRIPTION
# Summary
Since QR is not in production, this does not need to be a critical alarm that creates an OpsGenie alert.

**Note:** the production change to this alarm is because I've manually set it to warning, so the terraform is flipping it back to critical.