### PR TITLE
feat: add CloudWatch alarm for ECS task errors

### DIFF
--- a/aws/ecs/appstore_metrics_etl.tf
+++ b/aws/ecs/appstore_metrics_etl.tf
@@ -27,6 +27,7 @@ module "masked_appstore_metrics_etl" {
     bucket_name           = var.masked_metrics_bucket
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }
 
 module "unmasked_appstore_metrics_etl" {
@@ -53,4 +54,5 @@ module "unmasked_appstore_metrics_etl" {
     bucket_name           = var.unmasked_metrics_bucket
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }

--- a/aws/ecs/common_inputs.tf
+++ b/aws/ecs/common_inputs.tf
@@ -8,6 +8,11 @@ variable "subnet_id" {
   type        = string
 }
 
+variable "sns_topic_warning_name" {
+  description = "SNS topic name for warning alerts"
+  type        = string
+}
+
 ###
 # Buckets
 ###

--- a/aws/ecs/data_lookups.tf
+++ b/aws/ecs/data_lookups.tf
@@ -1,0 +1,3 @@
+data "aws_sns_topic" "alert_warning" {
+  name = var.sns_topic_warning_name
+}

--- a/aws/ecs/inapp_metrics_etl.tf
+++ b/aws/ecs/inapp_metrics_etl.tf
@@ -27,6 +27,7 @@ module "masked_inapp_metrics" {
     bucket_name           = var.masked_metrics_bucket
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }
 
 module "unmasked_inapp_metrics" {
@@ -53,4 +54,5 @@ module "unmasked_inapp_metrics" {
     bucket_name           = var.unmasked_metrics_bucket
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }

--- a/aws/ecs/server_metrics_etl.tf
+++ b/aws/ecs/server_metrics_etl.tf
@@ -29,6 +29,7 @@ module "masked_server_metrics_etl" {
     server_events_endpoint  = var.server_events_endpoint
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }
 
 module "unmasked_server_metrics_etl" {
@@ -57,4 +58,5 @@ module "unmasked_server_metrics_etl" {
     server_events_endpoint  = var.server_events_endpoint
   }
   log_retention_in_days = var.log_retention_in_days
+  ecs_task_alarm_action = data.aws_sns_topic.alert_warning.arn
 }

--- a/aws/modules/ecs_task/cloudwatch.tf
+++ b/aws/modules/ecs_task/cloudwatch.tf
@@ -24,5 +24,30 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
       security_groups = [var.sg_id]
     }
   }
+}
 
+resource "aws_cloudwatch_log_metric_filter" "ecs_task_error_metric" {
+  name           = "EcsTaskError-${var.name}"
+  pattern        = "Error"
+  log_group_name = aws_cloudwatch_log_group.log.name
+
+  metric_transformation {
+    name      = "EcsTaskError-${var.name}"
+    namespace = "CovidShieldMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecs_task_error_alarm" {
+  alarm_name          = "EcsTaskError-${var.name}"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.ecs_task_error_metric.name
+  namespace           = "CovidShieldMetrics"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "This monitors for errors in the ECS ${var.name} task"
+
+  alarm_actions = [var.ecs_task_alarm_action]
 }

--- a/aws/modules/ecs_task/inputs.tf
+++ b/aws/modules/ecs_task/inputs.tf
@@ -57,3 +57,7 @@ variable "event_rule_schedule_expression" {
 variable "log_retention_in_days" {
   type = string
 }
+
+variable "ecs_task_alarm_action" {
+  type = string
+}

--- a/env/staging/ecs/terragrunt.hcl
+++ b/env/staging/ecs/terragrunt.hcl
@@ -80,6 +80,7 @@ inputs = {
   masked_metrics_s3_arn   = dependency.s3.outputs.masked_metrics_arn
   masked_metrics_bucket   = dependency.s3.outputs.masked_metrics_id
   unmasked_metrics_bucket = dependency.s3.outputs.unmasked_metrics_id
+  sns_topic_warning_name  = "alert-warning"
 
 }
 


### PR DESCRIPTION
# Summary 
This is to catch cases where the scheduled ETL tasks cause an error.

# Expected changes
A new metric and CloudWatch alarm for each ETL task.

Closes cds-snc/covid-alert-metrics-etl#166