### PR TITLE
fix: ECS error alarm should trigger if any errors

### DIFF
--- a/aws/modules/ecs_task/cloudwatch.tf
+++ b/aws/modules/ecs_task/cloudwatch.tf
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_task_error_alarm" {
   namespace           = "CovidShieldMetrics"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "0"
   alarm_description   = "This monitors for errors in the ECS ${var.name} task"
 
   alarm_actions = [var.ecs_task_alarm_action]


### PR DESCRIPTION
# Summary
Set the allowed number of ECS errors to `0`.

# Expected change
* Update the six ECS CloudWatch alarms.
* API gateway redeploy.

Related cds-snc/covid-alert-metrics-etl#166