### PR TITLE
chore: disable API alarms in prep for debug metrics

### DIFF
--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -3,7 +3,7 @@ inputs = {
   sns_topic_warning_name   = "alert-warning"
   sns_topic_critical_name  = "alert-critical"
 
-  feature_api_alarms                        = true
+  feature_api_alarms                        = false
   api_gateway_400_error_threshold           = 3000
   api_gateway_500_error_threshold           = 1000
   api_gateway_min_invocations               = 100

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -25,7 +25,7 @@ inputs = {
   sns_topic_warning_name  = "alert-warning"
   sns_topic_critical_name = "alert-critical"
 
-  feature_api_alarms                        = true
+  feature_api_alarms                        = false
   api_gateway_400_error_threshold           = 95
   api_gateway_500_error_threshold           = 200
   api_gateway_min_invocations               = 0


### PR DESCRIPTION
# Summary 
This disables the max invocation alarm on the API gateway since
the app debug metrics will exceed this.

# Expected changes
* Remove API gateway max invocation alarms
* Redeploy API gateway stage