### PR TITLE
chore: disable the DynamoDB WCU alarms

### DIFF
--- a/env/production/aggregate_metrics_lambda/terragrunt.hcl
+++ b/env/production/aggregate_metrics_lambda/terragrunt.hcl
@@ -37,7 +37,7 @@ inputs = {
   dead_letter_queue_arn = dependency.sqs.outputs.dead_letter_queue_arn
   metrics_key_arn       = dependency.sqs.outputs.metrics_key_arn
 
-  feature_count_alarms               = true
+  feature_count_alarms               = false
   aggregate_metrics_max_avg_duration = 10000
   aggregate_metrics_dynamodb_wcu_max = 50000
 }

--- a/env/production/create_metrics_lambda/terragrunt.hcl
+++ b/env/production/create_metrics_lambda/terragrunt.hcl
@@ -53,7 +53,7 @@ inputs = {
   resource_id           = dependency.api_gateway.outputs.resource_id
   http_method           = dependency.api_gateway.outputs.http_method
 
-  feature_count_alarms            = true
+  feature_count_alarms            = false
   create_metrics_max_avg_duration = 10000
   create_metrics_dynamodb_wcu_max = 65000
 }

--- a/env/staging/aggregate_metrics_lambda/terragrunt.hcl
+++ b/env/staging/aggregate_metrics_lambda/terragrunt.hcl
@@ -37,7 +37,7 @@ inputs = {
   dead_letter_queue_arn = dependency.sqs.outputs.dead_letter_queue_arn
   metrics_key_arn       = dependency.sqs.outputs.metrics_key_arn
 
-  feature_count_alarms               = true
+  feature_count_alarms               = false
   aggregate_metrics_max_avg_duration = 60000
   aggregate_metrics_dynamodb_wcu_max = 300
 }

--- a/env/staging/create_metrics_lambda/terragrunt.hcl
+++ b/env/staging/create_metrics_lambda/terragrunt.hcl
@@ -53,7 +53,7 @@ inputs = {
   resource_id           = dependency.api_gateway.outputs.resource_id
   http_method           = dependency.api_gateway.outputs.http_method
 
-  feature_count_alarms            = true
+  feature_count_alarms            = false
   create_metrics_max_avg_duration = 10000
   create_metrics_dynamodb_wcu_max = 300
 }


### PR DESCRIPTION
# Summary 
These alarms will trigger while we are capturing debug metrics from the app.  Currently these alarms have their SNS topic alarm action removed.

# Expected changes
* Remove create and aggregate DynamoDB WCU alarms
* API gateway redeploy