### PR TITLE
feat: feature flag to deactivate qr code alarms

### DIFF
--- a/aws/cloudwatch_alarms/error_metrics.tf
+++ b/aws/cloudwatch_alarms/error_metrics.tf
@@ -1,5 +1,6 @@
 # Catch "QR parse errors" from the covid alert app
 resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_critical_threshold" {
+  count               = var.feature_qr_code_alarms ? 1 : 0
   alarm_name          = "metrics-app-errors-500-qr-parse-above-critical-threshold"
   comparison_operator = "GreaterThanThreshold"
   period              = "3600"
@@ -19,6 +20,7 @@ resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_cr
 }
 
 resource "aws_cloudwatch_metric_alarm" "metrics_app_errors_500_qr_parse_above_warning_threshold" {
+  count               = var.feature_qr_code_alarms ? 1 : 0
   alarm_name          = "metrics-app-errors-500-qr-parse-above-warning-threshold"
   comparison_operator = "GreaterThanThreshold"
   period              = "3600"

--- a/aws/cloudwatch_alarms/inputs.tf
+++ b/aws/cloudwatch_alarms/inputs.tf
@@ -23,6 +23,12 @@ variable "feature_api_alarms" {
   default     = true
 }
 
+variable "feature_qr_code_alarms" {
+  description = "Should QR code alarms be created"
+  type        = bool
+  default     = true
+}
+
 variable "api_gateway_400_error_threshold" {
   description = "Maximum sum of 4xx errors in a 60 second period before an alarm triggers"
   type        = string

--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -4,6 +4,7 @@ inputs = {
   sns_topic_critical_name  = "alert-critical"
 
   feature_api_alarms                        = true
+  feature_qr_code_alarms                    = false
   api_gateway_400_error_threshold           = 3000
   api_gateway_500_error_threshold           = 1000
   api_gateway_min_invocations               = 100

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -26,6 +26,7 @@ inputs = {
   sns_topic_critical_name = "alert-critical"
 
   feature_api_alarms                        = true
+  feature_qr_code_alarms                    = false
   api_gateway_400_error_threshold           = 95
   api_gateway_500_error_threshold           = 200
   api_gateway_min_invocations               = 0


### PR DESCRIPTION
Create feature flag to deactivate QR code CloudWatch alarms until the service is launched.