### PR TITLE
fix: body size restriction waf rule excluded

### DIFF
--- a/aws/api_gateway/waf.tf
+++ b/aws/api_gateway/waf.tf
@@ -45,6 +45,10 @@ resource "aws_wafv2_web_acl" "metrics_collection" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        excluded_rule {
+          name = "SizeRestrictions_BODY"
+        }
       }
     }
 


### PR DESCRIPTION
This is required due to the metrics payload growing to a size that exceeds this WAF rule that verifies that the request body size is at most 10,240 bytes.