### PR TITLE
chore: don't block so we can observe

### DIFF
--- a/aws/api_gateway/waf.tf
+++ b/aws/api_gateway/waf.tf
@@ -150,7 +150,7 @@ resource "aws_wafv2_web_acl" "metrics_collection" {
   rule {
     name = "metrics_collection_max_body_size"
     action {
-      block {}
+      count {}
     }
     priority = 102
 


### PR DESCRIPTION
Too risky to introduce in block mode. Will deploy as a count and observe. Testing was successful