### PR TITLE
fix: correctly convert chunked payloads to string

### DIFF
--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -21,8 +21,6 @@ exports.handler = async (event, context) => {
     // expire after 24 hours
     const ttl = (Math.floor(Date.now()/1000) + 86400).toString();
 
-    const eventBody = event.body;
-    
     try {
         // The maximum item size in DynamoDB is 400 KB
         const payloadLength = new TextEncoder().encode(event.body.payload).length;
@@ -38,8 +36,11 @@ exports.handler = async (event, context) => {
             const results = splitPayload(event.body.payload);
 
             for(const result of results){
+                let eventBody = {
+                    ...event.body
+                };
                 eventBody.payload = result;
-                await writePayload(eventBody, ttl);
+                await writePayload(JSON.stringify(eventBody), ttl);
             };
         }else{
             await writePayload(event.body, ttl);
@@ -89,7 +90,7 @@ const  writePayload = async (payload, ttl) => {
               N: ttl,
           },
           "raw": {
-              S: JSON.stringify(payload),
+              S: payload,
           },
       },
   };

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -20,6 +20,9 @@ exports.handler = async (event, context) => {
 
     // expire after 24 hours
     const ttl = (Math.floor(Date.now()/1000) + 86400).toString();
+    const eventBody = {
+        ...event.body
+    };
 
     try {
         // The maximum item size in DynamoDB is 400 KB
@@ -36,11 +39,8 @@ exports.handler = async (event, context) => {
             const results = splitPayload(event.body.payload);
 
             for(const result of results){
-                let eventBody = {
-                    ...event.body
-                };
-                eventBody.payload = result;
-                await writePayload(JSON.stringify(eventBody), ttl);
+                eventBody.payload = JSON.stringify(result);
+                await writePayload(eventBody, ttl);
             };
         }else{
             await writePayload(event.body, ttl);

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -20,9 +20,6 @@ exports.handler = async (event, context) => {
 
     // expire after 24 hours
     const ttl = (Math.floor(Date.now()/1000) + 86400).toString();
-    const eventBody = {
-        ...event.body
-    };
 
     try {
         // The maximum item size in DynamoDB is 400 KB
@@ -39,8 +36,11 @@ exports.handler = async (event, context) => {
             const results = splitPayload(event.body.payload);
 
             for(const result of results){
-                eventBody.payload = JSON.stringify(result);
-                await writePayload(eventBody, ttl);
+                let eventBody = {
+                    ...event.body
+                };
+                eventBody.payload = result;
+                await writePayload(JSON.stringify(eventBody), ttl);
             };
         }else{
             await writePayload(event.body, ttl);

--- a/env/staging/create_metrics_lambda/lambda/create_metric.test.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.test.js
@@ -113,7 +113,7 @@ describe("handler", () => {
       TableName: process.env.TABLE_NAME,
       Item: {
         expdate: {N: expect.any(String)},
-        raw: {S: JSON.stringify(event.body)},
+        raw: {S: event.body},
         uuid: {S: expect.any(String)},
       }
     }))


### PR DESCRIPTION
Corrects a bug where the metrics payload is being stringified excessively.