### PR TITLE
fix: correctly calculate payload size

### DIFF
--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
 
     try {
         // The maximum item size in DynamoDB is 400 KB
-        const payloadLength = new TextEncoder().encode(event.body.payload).length;
+        const payloadLength = new TextEncoder().encode(JSON.stringify(event.body.payload)).length;
         if (payloadLength > process.env.SPLIT_THRESHOLD){
             console.info(`Large payload being split; size: ${payloadLength}`);
 
@@ -62,7 +62,7 @@ const splitPayload = (payload) => {
   let chunk_size = payload.length;
   while (true) {
     let left = payload.slice(0, chunk_size);
-    if (new TextEncoder().encode(left).length < process.env.SPLIT_THRESHOLD) {
+    if (new TextEncoder().encode(JSON.stringify(left)).length < process.env.SPLIT_THRESHOLD) {
      break;
     }
   

--- a/env/staging/create_metrics_lambda/lambda/create_metric.test.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.test.js
@@ -131,14 +131,14 @@ describe("handler", () => {
   it("saves large event body successfully after splitting", async () => {
     
     process.env.TABLE_NAME = "foo"
-    process.env.SPLIT_THRESHOLD = 100;
+    process.env.SPLIT_THRESHOLD = 307200;
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large.json', 'utf8'))}
+    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_gigantic.json', 'utf8'))}
     const response = await handler(event)
 
-    expect(client.putItem).toHaveBeenCalledTimes(4)
+    expect(client.putItem).toHaveBeenCalledTimes(32)
 
     expect(response).toStrictEqual({
       isBase64Encoded: false,
@@ -153,7 +153,7 @@ describe("handler", () => {
   it("saves large event body successfully after splitting in half", async () => {
     
     process.env.TABLE_NAME = "foo"
-    process.env.SPLIT_THRESHOLD = 200;
+    process.env.SPLIT_THRESHOLD = 1000;
 
     client.promise = jest.fn(async () => true)
 


### PR DESCRIPTION
Noticed large payloads still generating errors in staging, this was due to the byte calculation not taking into consideration that the payload would be converted to string prior to sending to dynamodb.

In-order to calculate the correct # of bytes being sent to dynamodb the payload needs to be converted into a string when doing the byte calculation.