### PR TITLE
feat: lower split payload threshold from 300k to 200k

### DIFF
--- a/env/production/create_metrics_lambda/terragrunt.hcl
+++ b/env/production/create_metrics_lambda/terragrunt.hcl
@@ -56,7 +56,7 @@ inputs = {
   feature_count_alarms                = true
   create_metrics_max_avg_duration     = 10000
   create_metrics_dynamodb_wcu_max     = 65000
-  large_payload_split_threshold_bytes = 307200
+  large_payload_split_threshold_bytes = 204800
 }
 
 terraform {


### PR DESCRIPTION
Still experiencing `ERROR Upload failed ValidationException: Item size has exceeded the maximum allowed size`. How we're calculating byte size and how aws is validating may not be exactly the same, so some trial and error will be needed

This PR will reduce the threshold to 200k.