### PR TITLE
refactor: include body when calculating request length

### DIFF
--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -23,7 +23,7 @@ exports.handler = async (event, context) => {
 
     try {
         // The maximum item size in DynamoDB is 400 KB
-        const payloadLength = new TextEncoder().encode(JSON.stringify(event.body.payload)).length;
+        const payloadLength = new TextEncoder().encode(JSON.stringify(event.body)).length;
         if (payloadLength > process.env.SPLIT_THRESHOLD){
             console.info(`Large payload being split; size: ${payloadLength}`);
 

--- a/env/staging/create_metrics_lambda/lambda/create_metric.test.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.test.js
@@ -55,7 +55,7 @@ describe("handler", () => {
     })
   })
 
-  it("returns a 500 error code if large single payload can't be split", async () => {
+  it("returns a 200 error code if large single payload can't be split", async () => {
     process.env.TABLE_NAME = "foo"
     process.env.SPLIT_THRESHOLD = 50;
 
@@ -66,8 +66,8 @@ describe("handler", () => {
 
     expect(response).toStrictEqual({
       isBase64Encoded: false,
-      statusCode: 500,
-      body: JSON.stringify({ "status" : "UPLOAD FAILED" })
+      statusCode: 200,
+      body: JSON.stringify({ "status" : "RECORD DROPPED" })
     })
   })
 


### PR DESCRIPTION
Currently we're only looking at the payload length which is resulting in missing scenarios where the entire metric body is larger than DynamoDB can handle. This PR introduces changes that will calculate the entire body size to determine if a large payload should be split or dropped