### PR TITLE
feat: create s3 bucket

### DIFF
--- a/aws/s3/inputs.tf
+++ b/aws/s3/inputs.tf
@@ -1,0 +1,3 @@
+variable "billing_tag_value" {
+  type = string
+}

--- a/aws/s3/outputs.tf
+++ b/aws/s3/outputs.tf
@@ -13,4 +13,10 @@ output "unmasked_metrics_arn" {
   value = module.unmasked_metrics.arn
 }
 
+output "metrics_error_log_id" {
+  value = module.metrics_error_log.s3_bucket_id
+}
 
+output "metrics_error_log_arn" {
+  value = module.metrics_error_log.s3_bucket_arn
+}

--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -8,6 +8,9 @@ resource "random_string" "bucket_random_id" {
 locals {
   masked_metrics_bucket_name   = "masked-metrics-${random_string.bucket_random_id.result}-${var.env}"
   unmasked_metrics_bucket_name = "unmasked-metrics-${random_string.bucket_random_id.result}-${var.env}"
+  error_sample_bucket_name     = "error-samples-${random_string.bucket_random_id.result}-${var.env}"
+  log_bucket_name              = "logs-${random_string.bucket_random_id.result}-${var.env}"
+
 }
 
 
@@ -19,4 +22,28 @@ module "masked_metrics" {
 module "unmasked_metrics" {
   source = "../modules/s3"
   name   = local.unmasked_metrics_bucket_name
+}
+
+module "metrics_error_log" {
+  source      = "github.com/cds-snc/terraform-modules?ref=v0.0.28//S3"
+  bucket_name = local.error_sample_bucket_name
+  lifecycle_rule = [{
+    id      = "expire"
+    enabled = true
+    expiration = {
+      days = 3
+    }
+  }]
+  billing_tag_value = var.billing_tag_value
+  logging = {
+    "target_bucket" = module.log_bucket.s3_bucket_id
+    "target_prefix" = local.error_sample_bucket_name
+  }
+}
+
+module "log_bucket" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.28//S3_log_bucket"
+  bucket_name       = local.log_bucket_name
+  billing_tag_value = var.billing_tag_value
+
 }

--- a/env/staging/s3/.terraform.lock.hcl
+++ b/env/staging/s3/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.38.0"
-  constraints = "~> 3.0"
+  constraints = "~> 3.0, >= 3.36.0"
   hashes = [
     "h1:ARuS11ThIcUfmAQKWNXGPLOa1GheaIwkeCnMh9Mjvao=",
     "h1:qKEjN/EM56XT46vGY33eoq7nD6JuGqRqFp7tkzTrRM0=",


### PR DESCRIPTION
Create S3 bucket so error samples can be collected when payloads exceed the maximum dynamodb buffer size. This is to determine if these are legitimate payloads or invalid