### PR TITLE
feat: store error samples to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_STORE
 *.swp
 secret_env_vars.hcl
+node_modules

--- a/aws/create_metrics_lambda/create_metrics.tf
+++ b/aws/create_metrics_lambda/create_metrics.tf
@@ -21,6 +21,7 @@ resource "aws_lambda_function" "create_metrics" {
   environment {
     variables = {
       TABLE_NAME      = data.aws_dynamodb_table.raw_metrics.name
+      BUCKET_NAME     = var.metrics_error_log_bucket
       SPLIT_THRESHOLD = var.large_payload_split_threshold_bytes
     }
   }

--- a/aws/create_metrics_lambda/iam_policies.tf
+++ b/aws/create_metrics_lambda/iam_policies.tf
@@ -21,6 +21,11 @@ resource "aws_iam_role_policy_attachment" "createmetrics_dynamodb_put" {
   policy_arn = aws_iam_policy.create_metrics_put.arn
 }
 
+resource "aws_iam_role_policy_attachment" "createmetrics_s3_put" {
+  role       = aws_iam_role.create_metrics.name
+  policy_arn = aws_iam_policy.create_metrics_put_s3.arn
+}
+
 # Use AWS managed IAM policy
 ####
 # Provides minimum permissions for a Lambda function to execute while 
@@ -54,3 +59,27 @@ resource "aws_iam_policy" "create_metrics_put" {
   path   = "/"
   policy = data.aws_iam_policy_document.create_metrics_put.json
 }
+
+# create_metrics_put_s3
+
+data "aws_iam_policy_document" "create_metrics_put_s3" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+    resources = [
+      var.metrics_error_log_s3_arn,
+      "${var.metrics_error_log_s3_arn}/*"
+    ]
+  }
+
+}
+
+resource "aws_iam_policy" "create_metrics_put_s3" {
+  name   = "CovidAlertCreateMetricsPutItem"
+  path   = "/"
+  policy = data.aws_iam_policy_document.create_metrics_put_s3.json
+}
+

--- a/aws/create_metrics_lambda/iam_policies.tf
+++ b/aws/create_metrics_lambda/iam_policies.tf
@@ -78,7 +78,7 @@ data "aws_iam_policy_document" "create_metrics_put_s3" {
 }
 
 resource "aws_iam_policy" "create_metrics_put_s3" {
-  name   = "CovidAlertCreateMetricsPutItem"
+  name   = "CovidAlertCreateMetricsPutS3Object"
   path   = "/"
   policy = data.aws_iam_policy_document.create_metrics_put_s3.json
 }

--- a/aws/create_metrics_lambda/inputs.tf
+++ b/aws/create_metrics_lambda/inputs.tf
@@ -51,3 +51,13 @@ variable "large_payload_split_threshold_bytes" {
   type = string
 }
 
+variable "metrics_error_log_bucket" {
+  description = "(required) the name of the bucket that's used to store error samples"
+  type        = string
+}
+
+variable "metrics_error_log_s3_arn" {
+  description = "(required) the arn of the bucket that's used to store error samples"
+  type        = string
+
+}

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -54,7 +54,7 @@ exports.handler = async (event, context) => {
     } catch (err) {
         console.error(`Upload failed ${err}`);
         transactionStatus.statusCode = 500;
-        transactionStatus.body= JSON.stringify({ "status" : "UPLOAD FAILED" });
+        transactionStatus.body = JSON.stringify({ "status" : "UPLOAD FAILED" });
     }
 
     return transactionStatus;

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -3,6 +3,7 @@
 const
     AWS = require('aws-sdk'),
     dynamodb = new AWS.DynamoDB(),
+    s3 = new AWS.S3();
     crypto = require('crypto');
     
 const uuidv4 = () => {
@@ -28,7 +29,10 @@ exports.handler = async (event, context) => {
             console.info(`Large payload being split; size: ${payloadLength}`);
 
             if(!Array.isArray(event.body.payload) || event.body.payload.length === 1){
-                console.error(`Upload failed, unable to split large payload: ${payloadLength} > ${process.env.SPLIT_THRESHOLD}`);
+                const key = uuidv4()
+                console.error(`${key} - Upload failed, unable to split large payload: ${payloadLength} > ${process.env.SPLIT_THRESHOLD}`);
+                await saveSample(event.body, tag);
+
                 transactionStatus.statusCode = 200;
                 transactionStatus.body= JSON.stringify({ "status" : "RECORD DROPPED" }); 
                 return transactionStatus;
@@ -96,4 +100,14 @@ const  writePayload = async (payload, ttl) => {
   };
   
   return dynamodb.putItem(params).promise();
+};
+
+const  saveSample = async (data,key) => {
+  var params = {
+      Bucket : process.env.BUCKET_NAME,
+      Key : key,
+      Body : data
+  }
+
+  return s3.putObject(params).promise(); 
 };

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -3,7 +3,7 @@
 const
     AWS = require('aws-sdk'),
     dynamodb = new AWS.DynamoDB(),
-    s3 = new AWS.S3();
+    s3 = new AWS.S3(),
     crypto = require('crypto');
     
 const uuidv4 = () => {
@@ -29,9 +29,9 @@ exports.handler = async (event, context) => {
             console.info(`Large payload being split; size: ${payloadLength}`);
 
             if(!Array.isArray(event.body.payload) || event.body.payload.length === 1){
-                const key = uuidv4()
+                const key = uuidv4();
                 console.error(`${key} - Upload failed, unable to split large payload: ${payloadLength} > ${process.env.SPLIT_THRESHOLD}`);
-                await saveSample(event.body, tag);
+                await saveSample(event.body, key);
 
                 transactionStatus.statusCode = 200;
                 transactionStatus.body= JSON.stringify({ "status" : "RECORD DROPPED" }); 
@@ -102,7 +102,7 @@ const  writePayload = async (payload, ttl) => {
   return dynamodb.putItem(params).promise();
 };
 
-const  saveSample = async (data,key) => {
+const  saveSample = async (data, key) => {
   var params = {
       Bucket : process.env.BUCKET_NAME,
       Key : key,

--- a/env/staging/create_metrics_lambda/lambda/create_metric.test.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.test.js
@@ -9,18 +9,25 @@ jest.mock("aws-sdk", () => {
       putItem: jest.fn().mockReturnThis(),
       promise: jest.fn(),
   };
+  const mockS3 = {
+    putObject: jest.fn().mockReturnThis(),
+    promise: jest.fn(),
+  };
   return {
       __esModule: true,
       DynamoDB: jest.fn(() => mockDynamoDb),
+      S3: jest.fn(() => mockS3),
   };
 });
 
 
 describe("handler", () => {
   let client
+  let s3Client
 
   beforeAll(async (done) => {
     client = new AWS.DynamoDB();
+    s3Client = new AWS.S3();
     jest.spyOn(console, 'error').mockImplementation(jest.fn());
     done();
    });
@@ -29,6 +36,23 @@ describe("handler", () => {
     client.promise = jest.fn(async () => {throw "Error"})
 
     const event = {body: ""}
+    const response = await handler(event)
+
+    expect(response).toStrictEqual({
+      isBase64Encoded: false,
+      statusCode: 500,
+      body: JSON.stringify({ "status" : "UPLOAD FAILED" })
+    })
+  })
+
+  it("returns a 500 error code if the putObject fails", async () => {
+    process.env.TABLE_NAME = "foo"
+    process.env.BUCKET_NAME = "foo"
+    process.env.SPLIT_THRESHOLD = 1;
+
+    s3Client.promise = jest.fn(async () => {throw "Error"})
+
+    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
     const response = await handler(event)
 
     expect(response).toStrictEqual({
@@ -58,8 +82,10 @@ describe("handler", () => {
   it("returns a 200 error code if large single payload can't be split", async () => {
     process.env.TABLE_NAME = "foo"
     process.env.SPLIT_THRESHOLD = 50;
+    process.env.BUCKET_NAME = "bar"
 
     client.promise = jest.fn(async () => {throw "Error"})
+    s3Client.promise = jest.fn(async () => true)
 
     const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large_single.json', 'utf8'))}
     const response = await handler(event)
@@ -100,6 +126,23 @@ describe("handler", () => {
     })
   })
 
+  it("returns a 200 code if the putObject succeeds", async () => {
+    process.env.TABLE_NAME = "foo"
+    process.env.SPLIT_THRESHOLD = 1;
+    process.env.BUCKET_NAME = "bar"
+
+    s3Client.promise = jest.fn(async () => true)
+
+    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const response = await handler(event)
+
+    expect(response).toStrictEqual({
+      isBase64Encoded: false,
+      statusCode: 200,
+      body: JSON.stringify({ "status" : "RECORD DROPPED" })
+    })
+  })
+
   it("saves the event body with a random UUID and a TTL", async () => {
     process.env.TABLE_NAME = "foo"
     process.env.SPLIT_THRESHOLD = 307200;
@@ -126,6 +169,33 @@ describe("handler", () => {
 
     delete process.env.TABLE_NAME
     delete process.env.SPLIT_THRESHOLD
+  })
+
+  it("writes the event body to S3 if it's too large with random UUID as the key", async () => {
+    process.env.TABLE_NAME = "foo"
+    process.env.SPLIT_THRESHOLD = 1;
+    process.env.BUCKET_NAME = "bar"
+
+    s3Client.promise = jest.fn(async () => true)
+
+    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const response = await handler(event)
+
+    expect(s3Client.putObject).toHaveBeenCalledWith(expect.objectContaining({
+      Bucket: process.env.BUCKET_NAME,
+      Key: expect.any(String),
+      Body:  event.body
+    }))
+
+    expect(response).toStrictEqual({
+      isBase64Encoded: false,
+      statusCode: 200,
+      body: JSON.stringify({ "status" : "RECORD DROPPED" })
+    })
+
+    delete process.env.TABLE_NAME
+    delete process.env.SPLIT_THRESHOLD
+    delete process.env.BUCKET_NAME
   })
 
   it("saves large event body successfully after splitting", async () => {

--- a/env/staging/create_metrics_lambda/terragrunt.hcl
+++ b/env/staging/create_metrics_lambda/terragrunt.hcl
@@ -41,6 +41,17 @@ dependency "api_gateway" {
   }
 }
 
+dependency "s3" {
+  config_path = "../s3"
+
+  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs = {
+
+    metrics_error_log_id    = "metrics_error_log"
+    metrics_error_log_arn   = ""
+  }
+}
+
 inputs = {
   raw_metrics_arn        = dependency.dynamodb.outputs.raw_metrics_arn
   raw_metrics_stream_arn = dependency.dynamodb.outputs.raw_metrics_stream_arn
@@ -52,6 +63,9 @@ inputs = {
   rest_api_id           = dependency.api_gateway.outputs.rest_api_id
   resource_id           = dependency.api_gateway.outputs.resource_id
   http_method           = dependency.api_gateway.outputs.http_method
+
+  metrics_error_log_s3_arn   = dependency.s3.outputs.metrics_error_log_arn
+  metrics_error_log_bucket   = dependency.s3.outputs.metrics_error_log_id
 
   feature_count_alarms                = true
   create_metrics_max_avg_duration     = 10000

--- a/env/staging/create_metrics_lambda/terragrunt.hcl
+++ b/env/staging/create_metrics_lambda/terragrunt.hcl
@@ -47,8 +47,8 @@ dependency "s3" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs = {
 
-    metrics_error_log_id    = "metrics_error_log"
-    metrics_error_log_arn   = ""
+    metrics_error_log_id  = "metrics_error_log"
+    metrics_error_log_arn = ""
   }
 }
 
@@ -64,8 +64,8 @@ inputs = {
   resource_id           = dependency.api_gateway.outputs.resource_id
   http_method           = dependency.api_gateway.outputs.http_method
 
-  metrics_error_log_s3_arn   = dependency.s3.outputs.metrics_error_log_arn
-  metrics_error_log_bucket   = dependency.s3.outputs.metrics_error_log_id
+  metrics_error_log_s3_arn = dependency.s3.outputs.metrics_error_log_arn
+  metrics_error_log_bucket = dependency.s3.outputs.metrics_error_log_id
 
   feature_count_alarms                = true
   create_metrics_max_avg_duration     = 10000


### PR DESCRIPTION
If payload is too large, store a copy in s3 so it can be validated for bugs in metrics generation.