### PR TITLE
feat: reduce s3 lifecycle and more debugs for large payloads

### DIFF
--- a/aws/s3/inputs.tf
+++ b/aws/s3/inputs.tf
@@ -1,3 +1,7 @@
 variable "billing_tag_value" {
   type = string
 }
+
+variable "error_sampling_lifecycle_days" {
+  type = number
+}

--- a/aws/s3/s3.tf
+++ b/aws/s3/s3.tf
@@ -1,3 +1,4 @@
+data "aws_caller_identity" "current" {}
 resource "random_string" "bucket_random_id" {
   length  = 5
   upper   = false
@@ -31,19 +32,12 @@ module "metrics_error_log" {
     id      = "expire"
     enabled = true
     expiration = {
-      days = 3
+      days = var.error_sampling_lifecycle_days
     }
   }]
   billing_tag_value = var.billing_tag_value
   logging = {
-    "target_bucket" = module.log_bucket.s3_bucket_id
-    "target_prefix" = local.error_sample_bucket_name
+    target_bucket = "cbs-satellite-account-bucket${data.aws_caller_identity.current.account_id}"
+    target_prefix = "${data.aws_caller_identity.current.account_id}/s3_access_logs/${local.error_sample_bucket_name}/"
   }
-}
-
-module "log_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v0.0.28//S3_log_bucket"
-  bucket_name       = local.log_bucket_name
-  billing_tag_value = var.billing_tag_value
-
 }

--- a/env/production/create_metrics_lambda/lambda/create_metric.js
+++ b/env/production/create_metrics_lambda/lambda/create_metric.js
@@ -31,6 +31,12 @@ exports.handler = async (event, context) => {
             if(!Array.isArray(event.body.payload) || event.body.payload.length === 1){
                 const key = uuidv4();
                 console.error(`${key} - Upload failed, unable to split large payload: ${payloadLength} > ${process.env.SPLIT_THRESHOLD}`);
+                console.info(`${key} - Payload type: ${typeof event.body.payload}`);
+                console.info(`${key} - Payload isArray: ${Array.isArray(event.body.payload)}`);
+
+                if (event.body.payload) {
+                  console.info(`${key} - Payload length: ${event.body.payload.length}`);
+                }
                 await saveSample(JSON.stringify(event.body), key);
                 transactionStatus.statusCode = 200;
                 transactionStatus.body= JSON.stringify({ "status" : "RECORD DROPPED" }); 

--- a/env/production/s3/terragrunt.hcl
+++ b/env/production/s3/terragrunt.hcl
@@ -3,6 +3,10 @@ include {
   path = find_in_parent_folders()
 }
 
+inputs = {
+  error_sampling_lifecycle_days = 1
+}
+
 terraform {
   source = "git::https://github.com/cds-snc/covid-alert-metrics-terraform//aws/s3?ref=v${get_env("INFRASTRUCTURE_VERSION")}"
 }

--- a/env/staging/create_metrics_lambda/lambda/create_metric.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.js
@@ -31,6 +31,12 @@ exports.handler = async (event, context) => {
             if(!Array.isArray(event.body.payload) || event.body.payload.length === 1){
                 const key = uuidv4();
                 console.error(`${key} - Upload failed, unable to split large payload: ${payloadLength} > ${process.env.SPLIT_THRESHOLD}`);
+                console.info(`${key} - Payload type: ${typeof event.body.payload}`);
+                console.info(`${key} - Payload isArray: ${Array.isArray(event.body.payload)}`);
+
+                if (event.body.payload) {
+                  console.info(`${key} - Payload length: ${event.body.payload.length}`);
+                }
                 await saveSample(JSON.stringify(event.body), key);
                 transactionStatus.statusCode = 200;
                 transactionStatus.body= JSON.stringify({ "status" : "RECORD DROPPED" }); 

--- a/env/staging/s3/terragrunt.hcl
+++ b/env/staging/s3/terragrunt.hcl
@@ -3,6 +3,10 @@ include {
   path = find_in_parent_folders()
 }
 
+inputs = {
+  error_sampling_lifecycle_days = 7
+}
+
 terraform {
   source = "../../../aws//s3"
 }


### PR DESCRIPTION
Due to policy we will now only store s3 samples for 1 day to match the projects retention policies. S3 lifecycle rules are retroactive, so existing files will be deleted after 1 day.

This PR also adds:
- additional debug outputs to determine why large payloads are not being split.
- modified logging so the centralized logging bucket is used