### PR TITLE
refactor: parse json before trying to split

### DIFF
--- a/aws/create_metrics_lambda/create_metrics.tf
+++ b/aws/create_metrics_lambda/create_metrics.tf
@@ -11,6 +11,7 @@ resource "aws_lambda_function" "create_metrics" {
   # checkov:skip=CKV_AWS_116:Dead Letter Queue is handled by aggregate_metrics function code
   function_name = "create_metrics"
   filename      = "/tmp/lambda_create_metric.js.zip"
+  memory_size   = var.lambda_memory_size
 
   source_code_hash = data.archive_file.lambda_create_metric.output_base64sha256
 

--- a/aws/create_metrics_lambda/inputs.tf
+++ b/aws/create_metrics_lambda/inputs.tf
@@ -59,5 +59,8 @@ variable "metrics_error_log_bucket" {
 variable "metrics_error_log_s3_arn" {
   description = "(required) the arn of the bucket that's used to store error samples"
   type        = string
+}
 
+variable "lambda_memory_size" {
+  type = number
 }

--- a/env/production/create_metrics_lambda/terragrunt.hcl
+++ b/env/production/create_metrics_lambda/terragrunt.hcl
@@ -71,6 +71,7 @@ inputs = {
   create_metrics_max_avg_duration     = 10000
   create_metrics_dynamodb_wcu_max     = 65000
   large_payload_split_threshold_bytes = 204800
+  lambda_memory_size                  = 256
 }
 
 terraform {

--- a/env/staging/create_metrics_lambda/lambda/create_metric.test.js
+++ b/env/staging/create_metrics_lambda/lambda/create_metric.test.js
@@ -52,7 +52,7 @@ describe("handler", () => {
 
     s3Client.promise = jest.fn(async () => {throw "Error"})
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_small.json', 'utf8')}
     const response = await handler(event)
 
     expect(response).toStrictEqual({
@@ -68,7 +68,7 @@ describe("handler", () => {
 
     client.promise = jest.fn(async () => {throw "Error"})
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_large.json', 'utf8')}
 
     const response = await handler(event)
 
@@ -87,7 +87,7 @@ describe("handler", () => {
     client.promise = jest.fn(async () => {throw "Error"})
     s3Client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large_single.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_large_single.json', 'utf8')}
     const response = await handler(event)
 
     expect(response).toStrictEqual({
@@ -103,7 +103,7 @@ describe("handler", () => {
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_small.json', 'utf8')}
     const response = await handler(event)
 
     expect(response).toStrictEqual({
@@ -133,7 +133,7 @@ describe("handler", () => {
 
     s3Client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_small.json', 'utf8')}
     const response = await handler(event)
 
     expect(response).toStrictEqual({
@@ -149,7 +149,7 @@ describe("handler", () => {
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_small.json', 'utf8')}
     const response = await handler(event)
 
     expect(client.putItem).toHaveBeenCalledWith(expect.objectContaining({
@@ -178,13 +178,13 @@ describe("handler", () => {
 
     s3Client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_small.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_small.json', 'utf8')}
     const response = await handler(event)
 
     expect(s3Client.putObject).toHaveBeenCalledWith(expect.objectContaining({
       Bucket: process.env.BUCKET_NAME,
       Key: expect.any(String),
-      Body:  JSON.stringify(event.body)
+      Body:  event.body
     }))
 
     expect(response).toStrictEqual({
@@ -201,11 +201,11 @@ describe("handler", () => {
   it("saves large event body successfully after splitting", async () => {
     
     process.env.TABLE_NAME = "foo"
-    process.env.SPLIT_THRESHOLD = 307200;
+    process.env.SPLIT_THRESHOLD = 10000;
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_gigantic.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_gigantic.json', 'utf8')}
     const response = await handler(event)
 
     expect(client.putItem).toHaveBeenCalledTimes(32)
@@ -227,7 +227,7 @@ describe("handler", () => {
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_large.json', 'utf8')}
     const response = await handler(event)
 
     expect(client.putItem).toHaveBeenCalledTimes(2)
@@ -248,7 +248,7 @@ describe("handler", () => {
 
     client.promise = jest.fn(async () => true)
 
-    const event = {body: JSON.parse(fs.readFileSync('test_files/test_payload_large.json', 'utf8'))}
+    const event = {body: fs.readFileSync('test_files/test_payload_large.json', 'utf8')}
     const response = await handler(event)
 
     expect(client.putItem).toHaveBeenCalledTimes(1)

--- a/env/staging/create_metrics_lambda/terragrunt.hcl
+++ b/env/staging/create_metrics_lambda/terragrunt.hcl
@@ -71,6 +71,7 @@ inputs = {
   create_metrics_max_avg_duration     = 10000
   create_metrics_dynamodb_wcu_max     = 300
   large_payload_split_threshold_bytes = 307200
+  lambda_memory_size                  = 256
 }
 
 terraform {


### PR DESCRIPTION
Refactored to parse JSON formatted strings instead of assuming JSON.parse was already done at the API level.