### PR TITLE
feat: re-ordered WAF rules

### DIFF
--- a/aws/api_gateway/waf.tf
+++ b/aws/api_gateway/waf.tf
@@ -70,7 +70,7 @@ resource "aws_wafv2_web_acl" "metrics_collection" {
         }
         size = var.api_gateway_max_body_size
         text_transformation {
-          priority = 103
+          priority = 1
           type     = "NONE"
         }
       }


### PR DESCRIPTION
Re-ordered WAF rules so that custom rules that overlap with the AWS default rulesets are processed first. Also moved the rate limiting to a higher processing order so that security rules are not checked before rate limits.