### PR TITLE
fix: lower API gateway 4xx/5xx alarm thresholds

### DIFF
--- a/env/production/cloudwatch_alarms/terragrunt.hcl
+++ b/env/production/cloudwatch_alarms/terragrunt.hcl
@@ -5,8 +5,8 @@ inputs = {
 
   feature_api_alarms                        = true
   feature_qr_code_alarms                    = false
-  api_gateway_400_error_threshold           = 3000
-  api_gateway_500_error_threshold           = 1000
+  api_gateway_400_error_threshold           = 100
+  api_gateway_500_error_threshold           = 200
   api_gateway_min_invocations               = 100
   api_gateway_max_invocations               = 65000
   api_gateway_max_latency                   = 60000

--- a/env/staging/cloudwatch_alarms/terragrunt.hcl
+++ b/env/staging/cloudwatch_alarms/terragrunt.hcl
@@ -27,7 +27,7 @@ inputs = {
 
   feature_api_alarms                        = true
   feature_qr_code_alarms                    = false
-  api_gateway_400_error_threshold           = 95
+  api_gateway_400_error_threshold           = 100
   api_gateway_500_error_threshold           = 200
   api_gateway_min_invocations               = 0
   api_gateway_max_invocations               = 10000


### PR DESCRIPTION
# Summary
The CloudWatch 4xx and 5xx alarm thresholds were too high and caused us to miss a large spike in 4xx errors that was caused by phones sending payloads that were being rejected by the WAF ACL request size body rule.

# Related
* Closes #236
* #239 
* #240 
* #241 
* #242