### PR TITLE
fix: add packages required to install checkov

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ARG TERRAGRUNT_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends awscli ca-certificates curl git gnupg2 jq make openssh-client python3-pip vim zsh \
+    && apt-get -y install --no-install-recommends awscli build-essential ca-certificates curl git gnupg2 jq libffi-dev make openssh-client python3-dev python3-pip vim zsh \
     && apt-get autoremove -y && apt-get clean -y 
 
 # Install Terraform


### PR DESCRIPTION
# Summary
The checkov install was failing due to missing OS packages. This is
likely due to a change in how a more recent version of checkov is
being released.