### PR TITLE
feat: CloudWatch alarm if ECS warn/error event

### DIFF
--- a/aws/ecs/cloudwatch_ecs_events.tf
+++ b/aws/ecs/cloudwatch_ecs_events.tf
@@ -122,5 +122,5 @@ resource "aws_cloudwatch_metric_alarm" "ecs_warn_error_event" {
   threshold           = "0"
 
   alarm_description = "Metrics ECS warning or error event detected"
-  alarm_actions     = [data.aws_sns_topic.alert_warning]
+  alarm_actions     = [data.aws_sns_topic.alert_warning.arn]
 }

--- a/aws/ecs/cloudwatch_ecs_events.tf
+++ b/aws/ecs/cloudwatch_ecs_events.tf
@@ -120,6 +120,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_warn_error_event" {
   period              = "60"
   statistic           = "Sum"
   threshold           = "0"
+  treat_missing_data  = "notBreaching"
 
   alarm_description = "Metrics ECS warning or error event detected"
   alarm_actions     = [data.aws_sns_topic.alert_warning.arn]


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm if an ECS warning or error event is detected.
This will cover cases like task `OutOfMemoryErrors` that are not caught
by the current CloudWatch metric alarms.

# Related
* #246 