### PR TITLE
fix: ECS warn/error metric filter name

### DIFF
--- a/aws/ecs/cloudwatch_ecs_events.tf
+++ b/aws/ecs/cloudwatch_ecs_events.tf
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_log_group" "ecs_events" {
 # Alarm: trigger if a warning or error is detected in the ECS event logs
 #
 resource "aws_cloudwatch_log_metric_filter" "ecs_warn_error_event" {
-  name           = "MetricEcsWarnErrorEvent"
+  name           = "EcsWarnErrorEvent"
   pattern        = "?Warn ?Error"
   log_group_name = aws_cloudwatch_log_group.ecs_events.name
 


### PR DESCRIPTION
# Summary
Use a consistent name for the ECS warn/error metric filter
so that it can be easily referenced by the CloudWatch alarm.

# Note
⚠️ &nbsp;Change was applied locally to test.

# Related
* #246 