### PR TITLE
fix: metrics tasks unparseable dates

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Checkov security scan
         id: checkov
-        uses: bridgecrewio/checkov-action@6693d5f2dc45ab72428fcdb20e38b7fd14c8df50 #master as of Jun 10
+        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
         with:
           directory: .
           framework: terraform

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Checkov security scan
         id: checkov
-        uses: bridgecrewio/checkov-action@99bb2caf247dfd9f03cf984373bc6043d4e32ebf # v12.1347.0
+        uses: bridgecrewio/checkov-action@6693d5f2dc45ab72428fcdb20e38b7fd14c8df50 #master as of Jun 10
         with:
           directory: .
           framework: terraform

--- a/env/production/ecs/terragrunt.hcl
+++ b/env/production/ecs/terragrunt.hcl
@@ -49,7 +49,7 @@ inputs = {
   # Server Metrics Inputs
   server_metrics_etl_repository_url   = dependency.ecr.outputs.server_metrics_etl_repository_url
   server_metrics_etl_repository_arn   = dependency.ecr.outputs.server_metrics_etl_repository_arn
-  server_tag                          = "321045c31f01375d0ff1237c4f5efb869343e348"
+  server_tag                          = "687ea445d05e35b128d04fc8e56fc3e8ebaf2653"
   masked_server_schedule_expression   = "cron(0 5 * * ? *)"
   unmasked_server_schedule_expression = "cron(0 5 * * ? *)"
   server_events_endpoint              = "https://retrieval.covid-notification.alpha.canada.ca/events"
@@ -57,14 +57,14 @@ inputs = {
   # Appstore Metrics Inputs
   appstore_metrics_etl_repository_url   = dependency.ecr.outputs.appstore_metrics_etl_repository_url
   appstore_metrics_etl_repository_arn   = dependency.ecr.outputs.appstore_metrics_etl_repository_arn
-  appstore_tag                          = "321045c31f01375d0ff1237c4f5efb869343e348"
+  appstore_tag                          = "687ea445d05e35b128d04fc8e56fc3e8ebaf2653"
   masked_appstore_schedule_expression   = "cron(0 5 * * ? *)"
   unmasked_appstore_schedule_expression = "cron(0 5 * * ? *)"
 
   # Inapp Metrics Inputs
   inapp_metrics_etl_repository_url   = dependency.ecr.outputs.inapp_metrics_etl_repository_url
   inapp_metrics_etl_repository_arn   = dependency.ecr.outputs.inapp_metrics_etl_repository_arn
-  inapp_tag                          = "321045c31f01375d0ff1237c4f5efb869343e348"
+  inapp_tag                          = "687ea445d05e35b128d04fc8e56fc3e8ebaf2653"
   inapp_metrics_cpu_units            = 4096
   inapp_metrics_memory               = 30720
   masked_inapp_schedule_expression   = "cron(0 3 * * ? *)"


### PR DESCRIPTION
# Summary
Update the metrics ECS tasks with the fix for dates that
are not within Panda's parseable range.